### PR TITLE
feat: add lmdb binding

### DIFF
--- a/bench/lmdb.bench.ts
+++ b/bench/lmdb.bench.ts
@@ -1,0 +1,50 @@
+import {describe, bench, beforeAll, afterAll} from "@chainsafe/benchmark";
+import * as fs from "node:fs";
+import * as lmdb from "../src/lmdb.ts";
+import { intToBytes } from "../src/bytes.ts";
+
+describe("lmdb", () => {
+  let dbPath: string;
+  let env: lmdb.Environment;
+  beforeAll(() => {
+    dbPath = fs.mkdtempSync("db");
+    env = lmdb.environmentInit(dbPath);
+  });
+  afterAll(() => {
+    lmdb.environmentDeinit(env);
+    fs.rmSync(dbPath, {recursive: true, force: true});
+  });
+
+  bench({
+    id: "set 10k entries",
+    beforeEach: () => new Uint8Array(1000),
+    fn: (val) => {
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+      for (let i = 0; i < 10000; i++) {
+        lmdb.databaseSet(txn, db, intToBytes(i, 4, "le"), val);
+      }
+      lmdb.transactionCommit(txn);
+    },
+  });
+  bench({
+    id: "get 10k entries",
+    before: () => {
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+      const val = new Uint8Array(1000);
+      for (let i = 0; i < 10000; i++) {
+        lmdb.databaseSet(txn, db, intToBytes(i, 4, "le"), val);
+      }
+      lmdb.transactionCommit(txn);
+    },
+    fn: () => {
+      const txn = lmdb.transactionBegin(env, true);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+      for (let i = 0; i < 10000; i++) {
+        lmdb.databaseGet(txn, db, intToBytes(i, 4, "le"));
+      }
+      lmdb.transactionCommit(txn);
+    },
+  });
+});

--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,8 @@ pub fn build(b: *std.Build) void {
 
     const dep_hashtree = b.dependency("hashtree", .{});
 
+    const dep_lmdb = b.dependency("lmdb", .{});
+
     const dep_ssz = b.dependency("ssz", .{});
 
     const module_lodestar_z_bun = b.createModule(.{
@@ -46,5 +48,6 @@ pub fn build(b: *std.Build) void {
     tls_run_test.dependOn(&run_test_lodestar_z_bun.step);
 
     module_lodestar_z_bun.addImport("hashtree", dep_hashtree.module("hashtree"));
+    module_lodestar_z_bun.addImport("lmdb", dep_lmdb.module("lmdb"));
     module_lodestar_z_bun.addImport("ssz:persistent_merkle_tree", dep_ssz.module("persistent_merkle_tree"));
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,6 +14,10 @@
             .url = "git+https://github.com/chainsafe/ssz-z#592ca8544177072c369ec8267abd3035e236eb94",
             .hash = "ssz-0.1.0-yORmzKu_BAA2ywtTed4Xku3ogb4QkKn4IMzGrEpIId_z",
         },
+        .lmdb = .{
+            .url = "git+https://github.com/nDimensional/zig-lmdb#557de4d6d89fe6818e143715cea224cbd33c4f7e",
+            .hash = "lmdb-0.2.1-6TpzoNI-AADdNyodc3HCb9xo-srkPeDaAPWrrATdwNcf",
+        },
     },
     .paths = .{ "build.zig", "build.zig.zon", "zig" },
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "bench": "bun node_modules/.bin/benchmark bench/bytes.bench.ts",
+    "bench:files": "bun node_modules/.bin/benchmark",
+    "bench": "bun run bench:files bench/bytes.bench.ts",
     "generate": "bun node_modules/.bin/bun-ffi-z generate-binding"
   },
   "devDependencies": {

--- a/src/binding.ts
+++ b/src/binding.ts
@@ -30,6 +30,169 @@ const fns = {
     ],
     "returns": "i32"
   },
+  "lmdb_set_len_ptr": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "void"
+  },
+  "lmdb_set_err_ptr": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "void"
+  },
+  "lmdb_environment_init": {
+    "args": [
+      "ptr",
+      "u32",
+      "u64"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_environment_deinit": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "lmdb_transaction_begin": {
+    "args": [
+      "ptr",
+      "bool"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_transaction_abort": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "lmdb_transaction_commit": {
+    "args": [
+      "u64"
+    ],
+    "returns": "i32"
+  },
+  "lmdb_database_open": {
+    "args": [
+      "u64",
+      "ptr",
+      "bool",
+      "bool",
+      "bool"
+    ],
+    "returns": "u32"
+  },
+  "lmdb_database_get": {
+    "args": [
+      "ptr",
+      "u32",
+      "ptr",
+      "u32"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_database_set": {
+    "args": [
+      "u64",
+      "u32",
+      "ptr",
+      "u32",
+      "ptr",
+      "u32"
+    ],
+    "returns": "i32"
+  },
+  "lmdb_database_delete": {
+    "args": [
+      "u64",
+      "u32",
+      "ptr",
+      "u32"
+    ],
+    "returns": "i32"
+  },
+  "lmdb_database_cursor": {
+    "args": [
+      "ptr",
+      "u32"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_cursor_deinit": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "lmdb_cursor_get_current_key": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_cursor_get_current_value": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_cursor_set_current_value": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32"
+    ],
+    "returns": "i32"
+  },
+  "lmdb_cursor_delete_current_key": {
+    "args": [
+      "u64"
+    ],
+    "returns": "i32"
+  },
+  "lmdb_cursor_go_to_next": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_cursor_go_to_previous": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_cursor_go_to_first": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_cursor_go_to_last": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "ptr"
+  },
+  "lmdb_cursor_go_to_key": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32"
+    ],
+    "returns": "i32"
+  },
+  "lmdb_cursor_seek": {
+    "args": [
+      "ptr",
+      "ptr",
+      "u32"
+    ],
+    "returns": "ptr"
+  },
   "err_name": {
     "args": [
       "u16"

--- a/src/lmdb.ts
+++ b/src/lmdb.ts
@@ -1,0 +1,289 @@
+import { toArrayBuffer, type Pointer } from "bun:ffi";
+import {binding} from "./binding.ts";
+import { throwErr } from "./common.ts";
+
+// Buffers to hold length and error codes from zig binding
+const lenBuf = new Uint32Array(1);
+const errBuf = new Int32Array(1);
+binding.lmdb_set_len_ptr(lenBuf);
+binding.lmdb_set_err_ptr(errBuf);
+
+const textEncoder = new TextEncoder();
+
+/**
+ * LMDB environment handle.
+ */
+export type Environment = number & {["lmdb_environment"]: never};
+
+/**
+ * Initialize an LMDB environment.
+ * @param path The file path to the database directory.
+ * @param options Optional settings for the environment.
+ * @returns The initialized environment handle.
+ */
+export function environmentInit(path: string, options: { mapSize?: number; maxDbs?: number } = {}): Environment {
+  const env = binding.lmdb_environment_init(textEncoder.encode(path), options.maxDbs ?? 64, options.mapSize ?? 1024 * 1024 * 1024);
+  if (env === null) {
+    throwErr(errBuf[0] as number);
+  }
+  return env as number as Environment;
+}
+
+/**
+ * Deinitialize an LMDB environment.
+ * @param env The environment handle to deinitialize.
+ */
+export function environmentDeinit(env: Environment): void {
+  binding.lmdb_environment_deinit(env);
+}
+
+/**
+ * LMDB transaction handle.
+ */
+export type Transaction = number & {["lmdb_transaction"]: never};
+
+/**
+ * Begin a new transaction.
+ * @param env The environment handle.
+ * @param readOnly Whether the transaction is read-only. Default is true.
+ * @returns The started transaction handle.
+ */
+export function transactionBegin(env: Environment, readOnly = true): Transaction {
+  const txn = binding.lmdb_transaction_begin(env as number as Pointer, readOnly);
+  if (txn === null) {
+    throwErr(errBuf[0] as number);
+  }
+  return txn as number as Transaction;
+}
+
+/**
+ * Commit a transaction.
+ * This will persist any changes to the database.
+ * @param txn The transaction handle to commit.
+ */
+export function transactionCommit(txn: Transaction): void {
+  throwErr(binding.lmdb_transaction_commit(txn as number as Pointer));
+}
+
+/**
+ * Abort a transaction.
+ * This will discard any changes made during the transaction.
+ * @param txn The transaction handle to abort.
+ */
+export function transactionAbort(txn: Transaction): void {
+  binding.lmdb_transaction_abort(txn as number as Pointer);
+}
+
+/**
+ * LMDB database handle.
+ */
+export type Database = number & {["lmdb_database"]: never};
+
+/**
+ * Open a database within a transaction.
+ * @param txn The transaction handle.
+ * @param name The name of the database.
+ * @param options Optional settings for the database.
+ * @param options.create Whether to create the database if it doesn't exist. Default is false.
+ * @param options.integerKey Whether the database uses integer keys. Default is false.
+ * @param options.reverseKey Whether the database uses reverse keys. Default is false.
+ * @returns The opened database handle.
+ */
+export function databaseOpen(txn: Transaction, name: string, options: { create?: boolean, integerKey?: boolean, reverseKey?: boolean } = { create: false, integerKey: false, reverseKey: false} ): Database {
+  const dbi = binding.lmdb_database_open(txn as number as Pointer, textEncoder.encode(name), Boolean(options.create), Boolean(options.integerKey), Boolean(options.reverseKey));
+  if (dbi === 0) {
+    throwErr(errBuf[0] as number);
+  }
+  return dbi as number as Database;
+}
+
+/**
+ * Get a value from the database by key.
+ * 
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param txn The transaction handle.
+ * @param db The database handle.
+ * @param key The key to retrieve.
+ * @returns The value associated with the key, or null if not found.
+ */
+export function databaseGet(txn: Transaction, db: Database, key: Uint8Array): Uint8Array | null {
+  const ptr = binding.lmdb_database_get(txn as number as Pointer, db as number as Pointer, key, key.length);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+    return null;
+  }
+  return new Uint8Array(toArrayBuffer(ptr, 0, lenBuf[0]));
+}
+
+/**
+ * Set a value in the database.
+ * @param txn The transaction handle.
+ * @param db The database handle.
+ * @param key The key to set.
+ * @param value The value to associate with the key.
+ */
+export function databaseSet(txn: Transaction, db: Database, key: Uint8Array, value: Uint8Array): void {
+  throwErr(binding.lmdb_database_set(txn as number as Pointer, db as number as Pointer, key, key.length, value, value.length));
+}
+
+/**
+ * Delete a key from the database.
+ * @param txn The transaction handle.
+ * @param db The database handle.
+ * @param key The key to delete.
+ */
+export function databaseDelete(txn: Transaction, db: Database, key: Uint8Array): void {
+  throwErr(binding.lmdb_database_delete(txn as number as Pointer, db as number as Pointer, key, key.length));
+}
+
+/**
+ * LMDB cursor handle.
+ */
+export type Cursor = number & {["lmdb_cursor"]: never};
+
+/**
+ * Create a cursor for iterating over database entries.
+ * @param txn The transaction handle.
+ * @param db The database handle.
+ * @returns The created cursor handle.
+ */
+export function databaseCursor(txn: Transaction, db: Database): Cursor {
+  const cursor = binding.lmdb_database_cursor(txn as number as Pointer, db as number as Pointer) as number;
+  return throwErr(cursor) as Cursor;
+}
+
+/**
+ * Deinitialize a cursor.
+ * @param cursor The cursor handle to deinitialize.
+ */
+export function cursorDeinit(cursor: Cursor): void {
+  binding.lmdb_cursor_deinit(cursor as number as Pointer);
+}
+
+/**
+ * Get the current key the cursor is pointing to.
+ *
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param cursor The cursor handle.
+ * @returns The current key.
+ */
+export function cursorGetCurrentKey(cursor: Cursor): Uint8Array {
+  const ptr = binding.lmdb_cursor_get_current_key(cursor as number as Pointer);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+  }
+  return new Uint8Array(toArrayBuffer(ptr as Pointer, 0, lenBuf[0]));
+}
+
+/**
+ * Get the current value the cursor is pointing to.
+ *
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param cursor The cursor handle.
+ * @returns The current value.
+ */
+export function cursorGetCurrentValue(cursor: Cursor): Uint8Array {
+  const ptr = binding.lmdb_cursor_get_current_value(cursor as number as Pointer);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+  }
+  return new Uint8Array(toArrayBuffer(ptr as Pointer, 0, lenBuf[0]));
+}
+
+/**
+ * Move the cursor to the next entry in the database.
+ *
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param cursor The cursor handle.
+ * @returns The next key the cursor points to, or null if at the end.
+ */
+export function cursorGoToNext(cursor: Cursor): Uint8Array | null {
+  const ptr = binding.lmdb_cursor_go_to_next(cursor as number as Pointer);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+    return null;
+  }
+  return new Uint8Array(toArrayBuffer(ptr, 0, lenBuf[0]));
+}
+
+/**
+ * Move the cursor to the previous entry in the database.
+ *
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param cursor The cursor handle.
+ * @returns The previous key the cursor points to, or null if at the beginning.
+ */
+export function cursorGoToPrevious(cursor: Cursor): Uint8Array | null {
+  const ptr = binding.lmdb_cursor_go_to_previous(cursor as number as Pointer);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+    return null;
+  }
+  return new Uint8Array(toArrayBuffer(ptr, 0, lenBuf[0]));
+}
+
+/**
+ * Move the cursor to the first entry in the database.
+ *
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param cursor The cursor handle.
+ * @returns The first key the cursor points to, or null if the database is empty.
+ */
+export function cursorGoToFirst(cursor: Cursor): Uint8Array | null {
+  const ptr = binding.lmdb_cursor_go_to_first(cursor as number as Pointer);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+    return null;
+  }
+  return new Uint8Array(toArrayBuffer(ptr, 0, lenBuf[0]));
+}
+
+/**
+ * Move the cursor to the last entry in the database.
+ *
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param cursor The cursor handle.
+ * @returns The last key the cursor points to, or null if the database is empty.
+ */
+export function cursorGoToLast(cursor: Cursor): Uint8Array | null {
+  const ptr = binding.lmdb_cursor_go_to_last(cursor as number as Pointer);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+    return null;
+  }
+  return new Uint8Array(toArrayBuffer(ptr, 0, lenBuf[0]));
+}
+
+/**
+ * Move the cursor to a specific key in the database.
+ * @param cursor The cursor handle.
+ * @param key The key to move to.
+ */
+export function cursorGoToKey(cursor: Cursor, key: Uint8Array): void {
+  throwErr(binding.lmdb_cursor_go_to_key(cursor as number as Pointer, key, key.length));
+}
+
+/**
+ * Seek the cursor to the first entry greater than or equal to the specified key.
+ *
+ * The memory pointed to by the returned values is owned by the database. The caller need not dispose of the memory, and may not modify it in any way. For values returned in a read-only transaction any modification attempts will cause a SIGSEGV. 
+ * Values returned from the database are valid only until a subsequent update operation, or the end of the transaction. 
+ * @param cursor The cursor handle.
+ * @param key The key to seek to.
+ * @returns The key the cursor points to after seeking, or null if not found.
+ */
+export function cursorSeek(cursor: Cursor, key: Uint8Array): Uint8Array | null {
+  const ptr = binding.lmdb_cursor_seek(cursor as number as Pointer, key, key.length);
+  if (ptr === null) {
+    throwErr(errBuf[0] as number);
+    return null;
+  }
+  return new Uint8Array(toArrayBuffer(ptr as Pointer, 0, lenBuf[0]));
+}

--- a/test/lmdb.test.ts
+++ b/test/lmdb.test.ts
@@ -1,0 +1,179 @@
+import {afterEach, beforeEach, describe, expect, test} from "bun:test";
+import * as fs from "node:fs";
+
+import * as lmdb from "../src/lmdb.ts";
+
+describe("lmdb", () => {
+  let dbPath: string;
+  beforeEach(() => {
+    dbPath = fs.mkdtempSync("db");
+  });
+  afterEach(() => {
+    fs.rmSync(dbPath, {recursive: true, force: true});
+  });
+
+  test("get - empty db", () => {
+    const env = lmdb.environmentInit(dbPath);
+    const txn = lmdb.transactionBegin(env, false);
+    const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+
+    const key = new Uint8Array([1, 2, 3]);
+
+    {
+      const retrieved = lmdb.databaseGet(txn, db, key);
+      expect(retrieved).toBeNull();
+    }
+    {
+      const cursor = lmdb.databaseCursor(txn, db);
+      const retrieved = lmdb.cursorGoToFirst(cursor);
+      expect(retrieved).toBeNull();
+      lmdb.cursorDeinit(cursor);
+    }
+
+    lmdb.transactionCommit(txn);
+    lmdb.environmentDeinit(env);
+  });
+
+  test("get/set/delete", () => {
+    const env = lmdb.environmentInit(dbPath);
+    const txn = lmdb.transactionBegin(env, false);
+    const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+
+    const key = new Uint8Array([1, 2, 3]);
+    const value = new Uint8Array([4, 5, 6]);
+
+    lmdb.databaseSet(txn, db, key, value);
+    const retrieved = lmdb.databaseGet(txn, db, key);
+    expect(retrieved).toEqual(value);
+
+    lmdb.databaseDelete(txn, db, key);
+    const deleted = lmdb.databaseGet(txn, db, key);
+    expect(deleted).toBeNull();
+
+    lmdb.transactionCommit(txn);
+    lmdb.environmentDeinit(env);
+  });
+
+  test("value after commit", () => {
+    let retrieved: Uint8Array | null;
+    const key = new Uint8Array([1, 2, 3]);
+    const value = new Uint8Array([4, 5, 6]);
+    {
+      const env = lmdb.environmentInit(dbPath);
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+
+
+      lmdb.databaseSet(txn, db, key, value);
+      retrieved = lmdb.databaseGet(txn, db, key);
+      expect(retrieved).toEqual(value);
+
+      lmdb.databaseDelete(txn, db, key);
+      const deleted = lmdb.databaseGet(txn, db, key);
+      expect(deleted).toBeNull();
+
+      lmdb.transactionCommit(txn);
+      lmdb.environmentDeinit(env);
+    }
+    {
+      const env = lmdb.environmentInit(dbPath);
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+
+
+      lmdb.databaseSet(txn, db, key, new Uint8Array([7, 8, 9]));
+      lmdb.databaseDelete(txn, db, key);
+      const deleted = lmdb.databaseGet(txn, db, key);
+      expect(deleted).toBeNull();
+
+      lmdb.transactionCommit(txn);
+      lmdb.environmentDeinit(env);
+    }
+    // The value will NOT still be valid after the transaction is committed or subsequent update.
+    expect(retrieved).not.toEqual(value);
+  });
+
+  test("transaction commit", () => {
+    const env = lmdb.environmentInit(dbPath);
+    const key = new Uint8Array([1, 2, 3]);
+      const value = new Uint8Array([4, 5, 6]);
+    {
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+
+      lmdb.databaseSet(txn, db, key, value);
+      lmdb.transactionCommit(txn);
+    }
+
+    const txn = lmdb.transactionBegin(env, true);
+    const db = lmdb.databaseOpen(txn, "testdb");
+    const retrieved = lmdb.databaseGet(txn, db, key);
+    expect(retrieved).toEqual(value);
+    lmdb.transactionCommit(txn);
+
+    lmdb.environmentDeinit(env);
+  });
+
+  test("transaction abort", () => {
+    const env = lmdb.environmentInit(dbPath);
+    const key = new Uint8Array([1, 2, 3]);
+    const value = new Uint8Array([4, 5, 6]);
+    {
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+
+      lmdb.databaseSet(txn, db, key, value);
+      lmdb.transactionAbort(txn);
+    }
+
+    const txn = lmdb.transactionBegin(env, true);
+    expect(() => lmdb.databaseOpen(txn, "testdb")).toThrow();
+    lmdb.transactionCommit(txn);
+
+    lmdb.environmentDeinit(env);
+  });
+
+  test("cursor behavior", () => {
+    const env = lmdb.environmentInit(dbPath);
+    const key = (n: number) => new Uint8Array([n]);
+    const value = (n: number) => new Uint8Array([n]);
+
+    {
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+      for (let i = 0; i < 10; i++) {
+        lmdb.databaseSet(txn, db, key(i), value(i));
+      }
+      lmdb.transactionCommit(txn);
+    }
+
+    {
+      const txn = lmdb.transactionBegin(env, true);
+      const db = lmdb.databaseOpen(txn, "testdb");
+      const cursor = lmdb.databaseCursor(txn, db);
+      
+      for (let i = 0; i < 10; i++) {
+        const val = lmdb.cursorGoToNext(cursor);
+        expect(val).toEqual(key(i));
+      }
+      lmdb.cursorDeinit(cursor);
+      lmdb.transactionCommit(txn);
+    }
+
+    {
+      const txn = lmdb.transactionBegin(env, true);
+      const db = lmdb.databaseOpen(txn, "testdb");
+      const cursor = lmdb.databaseCursor(txn, db);
+      
+      const k = lmdb.cursorGoToLast(cursor);
+      expect(k).toEqual(key(9));
+      for (let i = 8; i >= 0; i--) {
+        const val = lmdb.cursorGoToPrevious(cursor);
+        expect(val).toEqual(key(i));
+      }
+      lmdb.cursorDeinit(cursor);
+      lmdb.transactionCommit(txn);
+    }
+    lmdb.environmentDeinit(env);
+  });
+});

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -5,6 +5,9 @@
         .hashtree = .{
             .url = "git+https://github.com/chainsafe/hashtree-z#6b96e3f0c7c1cc935bd9cfe1cfcbce84ed5a396a",
         },
+        .lmdb = .{
+            .url = "git+https://github.com/nDimensional/zig-lmdb#557de4d6d89fe6818e143715cea224cbd33c4f7e",
+        },
         .ssz = .{
             .url = "git+https://github.com/chainsafe/ssz-z#592ca8544177072c369ec8267abd3035e236eb94",
         },
@@ -22,6 +25,7 @@
                 .root_source_file = "zig/root.zig",
                 .imports = .{
                     .hashtree,
+                    .lmdb,
                     "ssz:persistent_merkle_tree",
                 },
             },

--- a/zig/lmdb.zig
+++ b/zig/lmdb.zig
@@ -1,0 +1,229 @@
+const std = @import("std");
+const lmdb = @import("lmdb");
+const toErrCode = @import("common.zig").toErrCode;
+
+var len_ptr: *u32 = undefined;
+var err_ptr: *i32 = undefined;
+
+pub export fn lmdb_set_len_ptr(ptr: *u32) void {
+    len_ptr = ptr;
+}
+pub export fn lmdb_set_err_ptr(ptr: *i32) void {
+    err_ptr = ptr;
+}
+
+// bun-ffi-z: lmdb_environment_init (ptr, u32, u64) ptr
+pub export fn lmdb_environment_init(path: [*c]const u8, max_dbs: u32, map_size: u64) u64 {
+    const env = lmdb.Environment.init(path, .{
+        .max_dbs = max_dbs,
+        .map_size = map_size,
+    }) catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    };
+    return @intFromPtr(env.ptr);
+}
+
+pub export fn lmdb_environment_deinit(env_ptr: u64) void {
+    const env = lmdb.Environment{ .ptr = @ptrFromInt(env_ptr) };
+    env.deinit();
+}
+
+// bun-ffi-z: lmdb_transaction_begin (ptr, bool) ptr
+pub export fn lmdb_transaction_begin(env_ptr: u64, read_only: bool) u64 {
+    const env = lmdb.Environment{ .ptr = @ptrFromInt(env_ptr) };
+    const txn = env.transaction(
+        .{ .mode = if (read_only) .ReadOnly else .ReadWrite },
+    ) catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    };
+    return @intFromPtr(txn.ptr);
+}
+
+pub export fn lmdb_transaction_abort(txn_ptr: u64) void {
+    const txn = lmdb.Transaction{ .ptr = @ptrFromInt(txn_ptr) };
+    txn.abort();
+}
+
+pub export fn lmdb_transaction_commit(txn_ptr: u64) i32 {
+    const txn = lmdb.Transaction{ .ptr = @ptrFromInt(txn_ptr) };
+    txn.commit() catch |e| return toErrCode(e);
+    return 0;
+}
+
+pub export fn lmdb_database_open(txn_ptr: u64, name: [*c]const u8, create: bool, integer_key: bool, reverse_key: bool) u32 {
+    const txn = lmdb.Transaction{ .ptr = @ptrFromInt(txn_ptr) };
+    const db = txn.database(name, .{
+        .create = create,
+        .integer_key = integer_key,
+        .reverse_key = reverse_key,
+    }) catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    };
+    return db.dbi;
+}
+
+// bun-ffi-z: lmdb_database_get (ptr, u32, ptr, u32) ptr
+pub export fn lmdb_database_get(txn_ptr: u64, db_ptr: u32, key: [*c]const u8, key_len: u32) u64 {
+    const db = lmdb.Database{
+        .txn = lmdb.Transaction{ .ptr = @ptrFromInt(txn_ptr) },
+        .dbi = db_ptr,
+    };
+    const val = db.get(key[0..key_len]) catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    } orelse {
+        err_ptr.* = 0;
+        return 0;
+    };
+    len_ptr.* = @intCast(val.len);
+    return @intFromPtr(val.ptr);
+}
+
+pub export fn lmdb_database_set(txn_ptr: u64, db_ptr: u32, key: [*c]const u8, key_len: u32, val: [*c]const u8, val_len: u32) i32 {
+    const db = lmdb.Database{
+        .txn = lmdb.Transaction{ .ptr = @ptrFromInt(txn_ptr) },
+        .dbi = db_ptr,
+    };
+    db.set(key[0..key_len], val[0..val_len]) catch |e| return toErrCode(e);
+    return 0;
+}
+
+pub export fn lmdb_database_delete(txn_ptr: u64, db_ptr: u32, key: [*c]const u8, key_len: u32) i32 {
+    const db = lmdb.Database{
+        .txn = lmdb.Transaction{ .ptr = @ptrFromInt(txn_ptr) },
+        .dbi = db_ptr,
+    };
+    db.delete(key[0..key_len]) catch |e| return toErrCode(e);
+    return 0;
+}
+
+// bun-ffi-z: lmdb_database_cursor (ptr, u32) ptr
+pub export fn lmdb_database_cursor(txn_ptr: u64, db_ptr: u32) u64 {
+    const db = lmdb.Database{
+        .txn = lmdb.Transaction{ .ptr = @ptrFromInt(txn_ptr) },
+        .dbi = db_ptr,
+    };
+    const cursor = db.cursor() catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    };
+    return @intFromPtr(cursor.ptr);
+}
+
+pub export fn lmdb_cursor_deinit(cursor_ptr: u64) void {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    cursor.deinit();
+}
+
+// bun-ffi-z: lmdb_cursor_get_current_key (ptr) ptr
+pub export fn lmdb_cursor_get_current_key(cursor_ptr: u64) u64 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    const key = cursor.getCurrentKey() catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    };
+    len_ptr.* = @intCast(key.len);
+    return @intFromPtr(key.ptr);
+}
+
+// bun-ffi-z: lmdb_cursor_get_current_value (ptr) ptr
+pub export fn lmdb_cursor_get_current_value(cursor_ptr: u64) u64 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    const value = cursor.getCurrentValue() catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    };
+    len_ptr.* = @intCast(value.len);
+    return @intFromPtr(value.ptr);
+}
+
+pub export fn lmdb_cursor_set_current_value(cursor_ptr: u64, val: [*c]const u8, val_len: u32) i32 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    cursor.setCurrentValue(val[0..val_len]) catch |e| return toErrCode(e);
+    return 0;
+}
+
+pub export fn lmdb_cursor_delete_current_key(cursor_ptr: u64) i32 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    cursor.deleteCurrentKey() catch |e| return toErrCode(e);
+    return 0;
+}
+
+// bun-ffi-z: lmdb_cursor_go_to_next (ptr) ptr
+pub export fn lmdb_cursor_go_to_next(cursor_ptr: u64) u64 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    const key = cursor.goToNext() catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    } orelse {
+        err_ptr.* = 0;
+        return 0;
+    };
+    len_ptr.* = @intCast(key.len);
+    return @intFromPtr(key.ptr);
+}
+
+// bun-ffi-z: lmdb_cursor_go_to_previous (ptr) ptr
+pub export fn lmdb_cursor_go_to_previous(cursor_ptr: u64) u64 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    const key = cursor.goToPrevious() catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    } orelse {
+        err_ptr.* = 0;
+        return 0;
+    };
+    len_ptr.* = @intCast(key.len);
+    return @intFromPtr(key.ptr);
+}
+
+// bun-ffi-z: lmdb_cursor_go_to_first (ptr) ptr
+pub export fn lmdb_cursor_go_to_first(cursor_ptr: u64) u64 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    const key = cursor.goToFirst() catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    } orelse {
+        err_ptr.* = 0;
+        return 0;
+    };
+    len_ptr.* = @intCast(key.len);
+    return @intFromPtr(key.ptr);
+}
+
+// bun-ffi-z: lmdb_cursor_go_to_last (ptr) ptr
+pub export fn lmdb_cursor_go_to_last(cursor_ptr: u64) u64 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    const key = cursor.goToLast() catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    } orelse {
+        err_ptr.* = 0;
+        return 0;
+    };
+    len_ptr.* = @intCast(key.len);
+    return @intFromPtr(key.ptr);
+}
+
+pub export fn lmdb_cursor_go_to_key(cursor_ptr: u64, key: [*c]const u8, key_len: u32) i32 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    cursor.goToKey(key[0..key_len]) catch |e| return toErrCode(e);
+    return 0;
+}
+
+// bun-ffi-z: lmdb_cursor_seek (ptr, ptr, u32) ptr
+pub export fn lmdb_cursor_seek(cursor_ptr: u64, key: [*c]const u8, key_len: u32) u64 {
+    const cursor = lmdb.Cursor{ .ptr = @ptrFromInt(cursor_ptr) };
+    const found_key = cursor.seek(key[0..key_len]) catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    } orelse {
+        err_ptr.* = 0;
+        return 0;
+    };
+    len_ptr.* = @intCast(found_key.len);
+    return @intFromPtr(found_key.ptr);
+}

--- a/zig/root.zig
+++ b/zig/root.zig
@@ -2,9 +2,11 @@ const std = @import("std");
 const hashtree = @import("hashtree.zig");
 const persistent_merkle_tree = @import("persistent_merkle_tree.zig");
 const bytes = @import("bytes.zig");
+const lmdb = @import("lmdb.zig");
 
 comptime {
     std.testing.refAllDecls(hashtree);
     std.testing.refAllDecls(persistent_merkle_tree);
     std.testing.refAllDecls(bytes);
+    std.testing.refAllDecls(lmdb);
 }


### PR DESCRIPTION
Description:
- Add [LMDB](http://www.lmdb.tech/doc/index.html) binding
- unit tests and basic benchmarks

Implementation note:
- bun-ffi has a convenient `ptr` type which converts a `u64` into a `number | null` (`null` when equal to 0)
- Since bun-ffi can only return pointers, ints, bools, something extra must be done to return slices (pointer + length) and error unions
- The strategy used here is:
  - Pass a js-controlled typed arrays (one for slice length and one for error code) to the zig binding layer. These buffers are written in methods that return slices or errors.
  - Any method that would return a slice, write the `slice.len` to the length buffer and return `slice.ptr` (treated as a bun-ffi `ptr`). The js layer can then recreate the slice as an ArrayBuffer by using the return value and the written value of the length buffer.
  - Any method that would return null (eg when a key is not found in the db), write 0 to the error buffer and return 0
  - Any method that would error, write the error code to the error buffer and return 0
