### PR TITLE
feat: add leveldb binding

### DIFF
--- a/bench/leveldb.bench.ts
+++ b/bench/leveldb.bench.ts
@@ -1,0 +1,77 @@
+import {describe, bench, beforeAll, afterAll} from "@chainsafe/benchmark";
+import * as fs from "node:fs";
+import * as leveldb from "../src/leveldb.ts";
+import { intToBytes } from "../src/bytes.ts";
+
+describe("leveldb", () => {
+  let dbPath: string;
+  let db: leveldb.DB;
+  beforeAll(() => {
+    dbPath = fs.mkdtempSync("db");
+    db = leveldb.dbOpen(dbPath, {create_if_missing: true});
+  });
+  afterAll(() => {
+    leveldb.dbClose(db);
+    fs.rmSync(dbPath, {recursive: true, force: true});
+  });
+
+  bench({
+    id: "set 10k entries",
+    beforeEach: () => new Uint8Array(1000),
+    fn: (val) => {
+      for (let i = 0; i < 10000; i++) {
+        leveldb.dbPut(db, intToBytes(i, 4, "le"), val);
+      }
+    },
+  });
+
+  bench({
+    id: "batch set 10k entries",
+    beforeEach: () => new Uint8Array(1000),
+    fn: (val) => {
+      const batch = [];
+      for (let i = 0; i < 10000; i++) {
+        batch.push({key: intToBytes(i, 4, "le"), value: val});
+      }
+      leveldb.dbWrite(db, batch);
+    },
+  });
+
+  bench({
+    id: "get 10k entries",
+    before: () => {
+      const val = new Uint8Array(1000);
+      const batch = [];
+      for (let i = 0; i < 10000; i++) {
+        batch.push({key: intToBytes(i, 4, "le"), value: val});
+      }
+      leveldb.dbWrite(db, batch);
+    },
+    fn: () => {
+      for (let i = 0; i < 10000; i++) {
+        leveldb.dbGet(db, intToBytes(i, 4, "le"));
+      }
+    },
+  });
+
+  bench({
+    id: "iterate 10k entries",
+    before: () => {
+      const val = new Uint8Array(1000);
+      const batch = [];
+      for (let i = 0; i < 10000; i++) {
+        batch.push({key: intToBytes(i, 4, "le"), value: val});
+      }
+      leveldb.dbWrite(db, batch);
+    },
+    fn: () => {
+      const iter = leveldb.dbIterator(db);
+      leveldb.iteratorSeekToFirst(iter);
+      for (let i = 0; i < 10000; i++) {
+        leveldb.iteratorKey(iter);
+        leveldb.iteratorNext(iter);
+      }
+      leveldb.iteratorDestroy(iter);
+    },
+  });
+});

--- a/bench/lmdb.bench.ts
+++ b/bench/lmdb.bench.ts
@@ -27,6 +27,7 @@ describe("lmdb", () => {
       lmdb.transactionCommit(txn);
     },
   });
+
   bench({
     id: "get 10k entries",
     before: () => {
@@ -44,6 +45,29 @@ describe("lmdb", () => {
       for (let i = 0; i < 10000; i++) {
         lmdb.databaseGet(txn, db, intToBytes(i, 4, "le"));
       }
+      lmdb.transactionCommit(txn);
+    },
+  });
+
+  bench({
+    id: "iterate 10k entries",
+    before: () => {
+      const txn = lmdb.transactionBegin(env, false);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+      const val = new Uint8Array(1000);
+      for (let i = 0; i < 10000; i++) {
+        lmdb.databaseSet(txn, db, intToBytes(i, 4, "le"), val);
+      }
+      lmdb.transactionCommit(txn);
+    },
+    fn: () => {
+      const txn = lmdb.transactionBegin(env, true);
+      const db = lmdb.databaseOpen(txn, "testdb", {create: true});
+      const cursor = lmdb.databaseCursor(txn, db);
+      for (let i = 0; i < 10000; i++) {
+        lmdb.cursorGoToNext(cursor)!;
+      }
+      lmdb.cursorDeinit(cursor);
       lmdb.transactionCommit(txn);
     },
   });

--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,8 @@ pub fn build(b: *std.Build) void {
 
     const dep_ssz = b.dependency("ssz", .{});
 
+    const dep_leveldb = b.dependency("leveldb", .{});
+
     const module_lodestar_z_bun = b.createModule(.{
         .root_source_file = b.path("zig/root.zig"),
         .target = target,
@@ -49,5 +51,6 @@ pub fn build(b: *std.Build) void {
 
     module_lodestar_z_bun.addImport("hashtree", dep_hashtree.module("hashtree"));
     module_lodestar_z_bun.addImport("lmdb", dep_lmdb.module("lmdb"));
+    module_lodestar_z_bun.addImport("leveldb", dep_leveldb.module("leveldb"));
     module_lodestar_z_bun.addImport("ssz:persistent_merkle_tree", dep_ssz.module("persistent_merkle_tree"));
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -18,6 +18,10 @@
             .url = "git+https://github.com/nDimensional/zig-lmdb#557de4d6d89fe6818e143715cea224cbd33c4f7e",
             .hash = "lmdb-0.2.1-6TpzoNI-AADdNyodc3HCb9xo-srkPeDaAPWrrATdwNcf",
         },
+        .leveldb = .{
+            .url = "git+https://github.com/chainsafe/leveldb#8ab81f3663ff04a30f30e2e95bcba0f50692a84c",
+            .hash = "leveldb-0.1.0-nY4h8AQnDQCzTiOrdGfiQiJRorrKfpVsGoHPDLEbvsMR",
+        },
     },
     .paths = .{ "build.zig", "build.zig.zon", "zig" },
 }

--- a/src/binding.ts
+++ b/src/binding.ts
@@ -201,6 +201,185 @@ const fns = {
     ],
     "returns": "ptr"
   },
+  "leveldb_set_len_ptr": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "void"
+  },
+  "leveldb_set_err_ptr": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "void"
+  },
+  "leveldb_free_": {
+    "args": [
+      "ptr"
+    ],
+    "returns": "void"
+  },
+  "leveldb_db_open": {
+    "args": [
+      "ptr",
+      "bool",
+      "bool",
+      "bool",
+      "u32",
+      "i32",
+      "u32",
+      "i32"
+    ],
+    "returns": "ptr"
+  },
+  "leveldb_db_close": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_db_put": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32",
+      "ptr",
+      "u32"
+    ],
+    "returns": "i32"
+  },
+  "leveldb_db_get": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32"
+    ],
+    "returns": "ptr"
+  },
+  "leveldb_db_delete": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32"
+    ],
+    "returns": "i32"
+  },
+  "leveldb_writebatch_create_": {
+    "args": [],
+    "returns": "ptr"
+  },
+  "leveldb_writebatch_destroy_": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_writebatch_clear_": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_writebatch_put_": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32",
+      "ptr",
+      "u32"
+    ],
+    "returns": "void"
+  },
+  "leveldb_writebatch_delete_": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32"
+    ],
+    "returns": "void"
+  },
+  "leveldb_writebatch_append_": {
+    "args": [
+      "u64",
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_db_write": {
+    "args": [
+      "u64",
+      "u64"
+    ],
+    "returns": "i32"
+  },
+  "leveldb_db_create_iterator": {
+    "args": [
+      "u64"
+    ],
+    "returns": "ptr"
+  },
+  "leveldb_iterator_destroy": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_iterator_valid": {
+    "args": [
+      "u64"
+    ],
+    "returns": "bool"
+  },
+  "leveldb_iterator_seek_to_first": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_iterator_seek_to_last": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_iterator_seek": {
+    "args": [
+      "u64",
+      "ptr",
+      "u32"
+    ],
+    "returns": "void"
+  },
+  "leveldb_iterator_next": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_iterator_prev": {
+    "args": [
+      "u64"
+    ],
+    "returns": "void"
+  },
+  "leveldb_iterator_key": {
+    "args": [
+      "u64"
+    ],
+    "returns": "ptr"
+  },
+  "leveldb_iterator_value": {
+    "args": [
+      "u64"
+    ],
+    "returns": "ptr"
+  },
+  "leveldb_iterator_get_error": {
+    "args": [
+      "u64"
+    ],
+    "returns": "i32"
+  },
   "err_name": {
     "args": [
       "u16"

--- a/src/leveldb.ts
+++ b/src/leveldb.ts
@@ -1,0 +1,172 @@
+import {toArrayBuffer, type Pointer} from "bun:ffi";
+import {binding} from "./binding.ts";
+import {throwErr} from "./common.ts";
+
+// Buffers to hold length and error codes from zig binding
+const lenBuf = new Uint32Array(1);
+const errBuf = new Int32Array(1);
+binding.leveldb_set_len_ptr(lenBuf);
+binding.leveldb_set_err_ptr(errBuf);
+
+const textEncoder = new TextEncoder();
+
+export type DB = number & {"leveldb_db": never};
+
+export function dbOpen(path: string, options: {
+  create_if_missing?: boolean;
+  error_if_exists?: boolean;
+  paranoid_checks?: boolean;
+  write_buffer_size?: number;
+  max_open_files?: number;
+  block_size?: number;
+  block_restart_interval?: number;
+} = {
+}): DB {
+  const db = binding.leveldb_db_open(
+    textEncoder.encode(path + "\0"),
+    options.create_if_missing ?? false,
+    options.error_if_exists ?? false,
+    options.paranoid_checks ?? true,
+    options.write_buffer_size ?? 4 * 1024 * 1024,
+    options.max_open_files ?? 1000,
+    options.block_size ?? 4 * 1024,
+    options.block_restart_interval ?? 16,
+  );
+  if (db === null) {
+    throwErr(errBuf[0] as number);
+  }
+  return db as number as DB;
+
+}
+
+export function dbClose(db: DB): void {
+  binding.leveldb_db_close(db);
+}
+
+export function dbPut(db: DB, key: Uint8Array, value: Uint8Array): void {
+  throwErr(binding.leveldb_db_put(
+    db,
+    key,
+    key.length,
+    value,
+    value.length,
+  ));
+}
+
+
+const data_finalizer = new FinalizationRegistry((data_ptr: number) => {
+  binding.leveldb_free_(data_ptr as Pointer);
+});
+
+export function dbGet(db: DB, key: Uint8Array): Uint8Array | null {
+  const valuePtr = binding.leveldb_db_get(
+    db,
+    key,
+    key.length,
+  );
+  if (valuePtr === null) {
+    throwErr(errBuf[0] as number);
+    return null;
+  }
+  const valueLen = lenBuf[0];
+  const valueBuffer = toArrayBuffer(
+    valuePtr,
+    0,
+    valueLen,
+  );
+  const value = new Uint8Array(valueBuffer);
+  data_finalizer.register(valueBuffer, valuePtr);
+  return value;
+}
+
+export function dbDelete(db: DB, key: Uint8Array): void {
+  throwErr(binding.leveldb_db_delete(
+    db,
+    key,
+    key.length,
+  ));
+}
+
+export function dbWrite(db: DB, batch: {key: Uint8Array; value: Uint8Array}[]): void {
+  const batchPtr = binding.leveldb_writebatch_create_() as number;
+  for (const {key, value} of batch) {
+    binding.leveldb_writebatch_put_(
+      batchPtr,
+      key,
+      key.length,
+      value,
+      value.length,
+    );
+  }
+  const result = binding.leveldb_db_write(db, batchPtr);
+  binding.leveldb_writebatch_destroy_(batchPtr);
+  throwErr(result);
+}
+
+export type Iterator = number & {"leveldb_iterator": never};
+
+export function dbIterator(db: DB): Iterator {
+  return binding.leveldb_db_create_iterator(db) as number as Iterator;
+}
+
+export function iteratorDestroy(it: Iterator): void {
+  binding.leveldb_iterator_destroy(it);
+}
+
+export function iteratorSeekToFirst(it: Iterator): void {
+  binding.leveldb_iterator_seek_to_first(it);
+}
+
+export function iteratorSeekToLast(it: Iterator): void {
+  binding.leveldb_iterator_seek_to_last(it);
+}
+
+export function iteratorSeek(it: Iterator, key: Uint8Array): void {
+  binding.leveldb_iterator_seek(it, key, key.length);
+}
+
+export function iteratorNext(it: Iterator): void {
+  binding.leveldb_iterator_next(it);
+}
+
+export function iteratorPrev(it: Iterator): void {
+  binding.leveldb_iterator_prev(it);
+}
+
+export function iteratorValid(it: Iterator): boolean {
+  return binding.leveldb_iterator_valid(it);
+}
+
+export function iteratorKey(it: Iterator): Uint8Array {
+  const keyPtr = binding.leveldb_iterator_key(it);
+  if (keyPtr === null) {
+    throwErr(errBuf[0] as number);
+  }
+  const keyLen = lenBuf[0];
+  return new Uint8Array(
+    toArrayBuffer(
+      keyPtr as Pointer,
+      0,
+      keyLen,
+    )
+  );
+}
+
+export function iteratorValue(it: Iterator): Uint8Array {
+  const valuePtr = binding.leveldb_iterator_value(it);
+  if (valuePtr === null) {
+    throwErr(errBuf[0] as number);
+  }
+  const valueLen = lenBuf[0];
+  return new Uint8Array(
+    toArrayBuffer(
+      valuePtr as Pointer,
+      0,
+      valueLen,
+    )
+  );
+}
+
+export function iteratorError(it: Iterator): void {
+  throwErr(binding.leveldb_iterator_get_error(it));
+}

--- a/test/leveldb.test.ts
+++ b/test/leveldb.test.ts
@@ -1,0 +1,81 @@
+import {afterEach, beforeEach, describe, expect, test} from "bun:test";
+import * as fs from "node:fs";
+
+import * as leveldb from "../src/leveldb.ts";
+
+describe("leveldb", () => {
+  let dbPath: string;
+  beforeEach(() => {
+    dbPath = fs.mkdtempSync("db");
+  });
+  afterEach(() => {
+    fs.rmSync(dbPath, {recursive: true, force: true});
+  });
+
+  test("get/set/delete", () => {
+    const db = leveldb.dbOpen(dbPath, {create_if_missing: true});
+
+    const key = new Uint8Array([1, 2, 3]);
+    const value = new Uint8Array([4, 5, 6]);
+
+    leveldb.dbPut(db, key, value);
+    const retrieved = leveldb.dbGet(db, key);
+    expect(retrieved).toEqual(value);
+
+    leveldb.dbDelete(db, key);
+    const deleted = leveldb.dbGet(db, key);
+    expect(deleted).toBeNull();
+
+    leveldb.dbClose(db);
+  });
+
+  test("batch write", () => {
+    const db = leveldb.dbOpen(dbPath, {create_if_missing: true});
+
+    const batch = [
+      {key: new Uint8Array([1]), value: new Uint8Array([10])},
+      {key: new Uint8Array([2]), value: new Uint8Array([20])},
+      {key: new Uint8Array([3]), value: new Uint8Array([30])},
+    ];
+
+    leveldb.dbWrite(db, batch);
+
+    for (const {key, value} of batch) {
+      const retrieved = leveldb.dbGet(db, key);
+      expect(retrieved).toEqual(value);
+    }
+
+    leveldb.dbClose(db);
+  });
+
+  test("iterator", () => {
+    const db = leveldb.dbOpen(dbPath, {create_if_missing: true});
+    
+    const entries = [
+      {key: new Uint8Array([1]), value: new Uint8Array([10])},
+      {key: new Uint8Array([2]), value: new Uint8Array([20])},
+      {key: new Uint8Array([3]), value: new Uint8Array([30])},
+    ];
+
+    for (const {key, value} of entries) {
+      leveldb.dbPut(db, key, value);
+    }
+
+    const iter = leveldb.dbIterator(db);
+    leveldb.iteratorSeekToFirst(iter);
+
+    let index = 0;
+    while (leveldb.iteratorValid(iter)) {
+      const key = leveldb.iteratorKey(iter);
+      const value = leveldb.iteratorValue(iter);
+      expect(key).toEqual(entries[index]!.key);
+      expect(value).toEqual(entries[index]!.value);
+      index++;
+      leveldb.iteratorNext(iter);
+    }
+    expect(index).toBe(entries.length);
+
+    leveldb.iteratorDestroy(iter);
+    leveldb.dbClose(db);
+  });
+});

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -11,6 +11,9 @@
         .ssz = .{
             .url = "git+https://github.com/chainsafe/ssz-z#592ca8544177072c369ec8267abd3035e236eb94",
         },
+        .leveldb = .{
+            .url = "git+https://github.com/chainsafe/leveldb#8ab81f3663ff04a30f30e2e95bcba0f50692a84c",
+        },
     },
     .fingerprint = 0xed854bdae2354180,
     .minimum_zig_version = "0.14.1",
@@ -26,6 +29,7 @@
                 .imports = .{
                     .hashtree,
                     .lmdb,
+                    .leveldb,
                     "ssz:persistent_merkle_tree",
                 },
             },

--- a/zig/leveldb.zig
+++ b/zig/leveldb.zig
@@ -1,0 +1,200 @@
+const std = @import("std");
+const leveldb = @import("leveldb");
+const toErrCode = @import("common.zig").toErrCode;
+
+var len_ptr: *u32 = undefined;
+var err_ptr: *i32 = undefined;
+
+pub export fn leveldb_set_len_ptr(ptr: *u32) void {
+    len_ptr = ptr;
+}
+pub export fn leveldb_set_err_ptr(ptr: *i32) void {
+    err_ptr = ptr;
+}
+
+pub export fn leveldb_free_(data: [*c]const u8) void {
+    leveldb.free(data);
+}
+
+// bun-ffi-z: leveldb_db_open (ptr, bool, bool, bool, u32, i32, u32, i32) ptr
+pub export fn leveldb_db_open(
+    path: [*c]const u8,
+    create_if_missing: bool,
+    error_if_exists: bool,
+    paranoid_checks: bool,
+    write_buffer_size: u32,
+    max_open_files: i32,
+    block_size: u32,
+    block_restart_interval: i32,
+) u64 {
+    var options = leveldb.Options.create();
+    defer options.destroy();
+
+    options.setCreateIfMissing(create_if_missing);
+    options.setErrorIfExists(error_if_exists);
+    options.setParanoidChecks(paranoid_checks);
+    options.setWriteBufferSize(write_buffer_size);
+    options.setMaxOpenFiles(max_open_files);
+    options.setBlockSize(block_size);
+    options.setBlockRestartInterval(block_restart_interval);
+
+    const db = leveldb.DB.open(&options, std.mem.span(path)) catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    };
+    return @intFromPtr(db.inner);
+}
+
+pub export fn leveldb_db_close(db_ptr: u64) void {
+    var db = leveldb.DB{ .inner = @ptrFromInt(db_ptr) };
+    db.close();
+}
+
+pub export fn leveldb_db_put(db_ptr: u64, key: [*c]const u8, key_len: u32, value: [*c]const u8, value_len: u32) i32 {
+    var db = leveldb.DB{ .inner = @ptrFromInt(db_ptr) };
+
+    var options = leveldb.WriteOptions.create();
+    defer options.destroy();
+
+    db.put(&options, key[0..key_len], value[0..value_len]) catch |e| return toErrCode(e);
+    return 0;
+}
+
+// bun-ffi-z: leveldb_db_get (u64, ptr, u32) ptr
+pub export fn leveldb_db_get(db_ptr: u64, key: [*c]const u8, key_len: u32) u64 {
+    var db = leveldb.DB{ .inner = @ptrFromInt(db_ptr) };
+
+    var options = leveldb.ReadOptions.create();
+    defer options.destroy();
+
+    const value = db.get(&options, key[0..key_len]) catch |e| {
+        err_ptr.* = toErrCode(e);
+        return 0;
+    } orelse {
+        err_ptr.* = 0;
+        return 0;
+    };
+    len_ptr.* = @intCast(value.len);
+    return @intFromPtr(value.ptr);
+}
+
+pub export fn leveldb_db_delete(db_ptr: u64, key: [*c]const u8, key_len: u32) i32 {
+    var db = leveldb.DB{ .inner = @ptrFromInt(db_ptr) };
+
+    var options = leveldb.WriteOptions.create();
+    defer options.destroy();
+
+    db.delete(&options, key[0..key_len]) catch |e| return toErrCode(e);
+    return 0;
+}
+
+// bun-ffi-z: leveldb_writebatch_create_ () ptr
+pub export fn leveldb_writebatch_create_() u64 {
+    const batch = leveldb.WriteBatch.create();
+    return @intFromPtr(batch.inner);
+}
+
+pub export fn leveldb_writebatch_destroy_(ptr: u64) void {
+    var batch = leveldb.WriteBatch{ .inner = @ptrFromInt(ptr) };
+    batch.destroy();
+}
+
+pub export fn leveldb_writebatch_clear_(ptr: u64) void {
+    var batch = leveldb.WriteBatch{ .inner = @ptrFromInt(ptr) };
+    batch.clear();
+}
+
+pub export fn leveldb_writebatch_put_(ptr: u64, key: [*c]const u8, key_len: u32, value: [*c]const u8, value_len: u32) void {
+    var batch = leveldb.WriteBatch{ .inner = @ptrFromInt(ptr) };
+    batch.put(key[0..key_len], value[0..value_len]);
+}
+
+pub export fn leveldb_writebatch_delete_(ptr: u64, key: [*c]const u8, key_len: u32) void {
+    var batch = leveldb.WriteBatch{ .inner = @ptrFromInt(ptr) };
+    batch.delete(key[0..key_len]);
+}
+
+pub export fn leveldb_writebatch_append_(dest_ptr: u64, src_ptr: u64) void {
+    var dest = leveldb.WriteBatch{ .inner = @ptrFromInt(dest_ptr) };
+    const src = leveldb.WriteBatch{ .inner = @ptrFromInt(src_ptr) };
+    dest.append(&src);
+}
+
+pub export fn leveldb_db_write(db_ptr: u64, batch_ptr: u64) i32 {
+    var db = leveldb.DB{ .inner = @ptrFromInt(db_ptr) };
+    var batch = leveldb.WriteBatch{ .inner = @ptrFromInt(batch_ptr) };
+
+    var options = leveldb.WriteOptions.create();
+    defer options.destroy();
+
+    db.write(&options, &batch) catch |e| return toErrCode(e);
+    return 0;
+}
+
+// bun-ffi-z: leveldb_db_create_iterator (u64) ptr
+pub export fn leveldb_db_create_iterator(db_ptr: u64) u64 {
+    var db = leveldb.DB{ .inner = @ptrFromInt(db_ptr) };
+
+    var options = leveldb.ReadOptions.create();
+    defer options.destroy();
+
+    const iter = db.createIterator(&options);
+    return @intFromPtr(iter.inner);
+}
+
+pub export fn leveldb_iterator_destroy(iter_ptr: u64) void {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    iter.destroy();
+}
+
+pub export fn leveldb_iterator_valid(iter_ptr: u64) bool {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    return iter.valid();
+}
+
+pub export fn leveldb_iterator_seek_to_first(iter_ptr: u64) void {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    iter.seekToFirst();
+}
+
+pub export fn leveldb_iterator_seek_to_last(iter_ptr: u64) void {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    iter.seekToLast();
+}
+
+pub export fn leveldb_iterator_seek(iter_ptr: u64, key: [*c]const u8, key_len: u32) void {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    iter.seek(key[0..key_len]);
+}
+
+pub export fn leveldb_iterator_next(iter_ptr: u64) void {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    iter.next();
+}
+
+pub export fn leveldb_iterator_prev(iter_ptr: u64) void {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    iter.prev();
+}
+
+// bun-ffi-z: leveldb_iterator_key (u64) ptr
+pub export fn leveldb_iterator_key(iter_ptr: u64) u64 {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    const key = iter.key();
+    len_ptr.* = @intCast(key.len);
+    return @intFromPtr(key.ptr);
+}
+
+// bun-ffi-z: leveldb_iterator_value (u64) ptr
+pub export fn leveldb_iterator_value(iter_ptr: u64) u64 {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    const value = iter.value();
+    len_ptr.* = @intCast(value.len);
+    return @intFromPtr(value.ptr);
+}
+
+pub export fn leveldb_iterator_get_error(iter_ptr: u64) i32 {
+    var iter = leveldb.Iterator{ .inner = @ptrFromInt(iter_ptr) };
+    iter.getError() catch |e| return toErrCode(e);
+    return 0;
+}

--- a/zig/root.zig
+++ b/zig/root.zig
@@ -3,10 +3,12 @@ const hashtree = @import("hashtree.zig");
 const persistent_merkle_tree = @import("persistent_merkle_tree.zig");
 const bytes = @import("bytes.zig");
 const lmdb = @import("lmdb.zig");
+const leveldb = @import("leveldb.zig");
 
 comptime {
     std.testing.refAllDecls(hashtree);
     std.testing.refAllDecls(persistent_merkle_tree);
     std.testing.refAllDecls(bytes);
     std.testing.refAllDecls(lmdb);
+    std.testing.refAllDecls(leveldb);
 }


### PR DESCRIPTION
- Add leveldb binding (uses [our fork](https://github.com/chainsafe/leveldb) of leveldb that is built using the zig build system)
- Add basic tests
- Add basic benchmark

Comparison between lmdb and leveldb is interesting, with leveldb being less performant across the board.
May be a misconfiguration issue.