### PR TITLE
chore: more db benchmarks

### DIFF
--- a/bench/leveldb.bench.ts
+++ b/bench/leveldb.bench.ts
@@ -15,63 +15,66 @@ describe("leveldb", () => {
     fs.rmSync(dbPath, {recursive: true, force: true});
   });
 
-  bench({
-    id: "set 10k entries",
-    beforeEach: () => new Uint8Array(1000),
-    fn: (val) => {
-      for (let i = 0; i < 10000; i++) {
-        leveldb.dbPut(db, intToBytes(i, 4, "le"), val);
-      }
-    },
-  });
 
-  bench({
-    id: "batch set 10k entries",
-    beforeEach: () => new Uint8Array(1000),
-    fn: (val) => {
-      const batch = [];
-      for (let i = 0; i < 10000; i++) {
-        batch.push({key: intToBytes(i, 4, "le"), value: val});
-      }
-      leveldb.dbWrite(db, batch);
-    },
-  });
+  for (const n of [1, 10, 100, 1000, 10000]) {
+    bench({
+      id: `set ${n} entries`,
+      beforeEach: () => new Uint8Array(1000),
+      fn: (val) => {
+        for (let i = 0; i < n; i++) {
+          leveldb.dbPut(db, intToBytes(i, 4, "le"), val);
+        }
+      },
+    });
 
-  bench({
-    id: "get 10k entries",
-    before: () => {
-      const val = new Uint8Array(1000);
-      const batch = [];
-      for (let i = 0; i < 10000; i++) {
-        batch.push({key: intToBytes(i, 4, "le"), value: val});
-      }
-      leveldb.dbWrite(db, batch);
-    },
-    fn: () => {
-      for (let i = 0; i < 10000; i++) {
-        leveldb.dbGet(db, intToBytes(i, 4, "le"));
-      }
-    },
-  });
+    bench({
+      id: `batch set ${n} entries`,
+      beforeEach: () => new Uint8Array(1000),
+      fn: (val) => {
+        const batch = [];
+        for (let i = 0; i < n; i++) {
+          batch.push({key: intToBytes(i, 4, "le"), value: val});
+        }
+        leveldb.dbWrite(db, batch);
+      },
+    });
 
-  bench({
-    id: "iterate 10k entries",
-    before: () => {
-      const val = new Uint8Array(1000);
-      const batch = [];
-      for (let i = 0; i < 10000; i++) {
-        batch.push({key: intToBytes(i, 4, "le"), value: val});
-      }
-      leveldb.dbWrite(db, batch);
-    },
-    fn: () => {
-      const iter = leveldb.dbIterator(db);
-      leveldb.iteratorSeekToFirst(iter);
-      for (let i = 0; i < 10000; i++) {
-        leveldb.iteratorKey(iter);
-        leveldb.iteratorNext(iter);
-      }
-      leveldb.iteratorDestroy(iter);
-    },
-  });
+    bench({
+      id: `get ${n} entries`,
+      before: () => {
+        const val = new Uint8Array(1000);
+        const batch = [];
+        for (let i = 0; i < n; i++) {
+          batch.push({key: intToBytes(i, 4, "le"), value: val});
+        }
+        leveldb.dbWrite(db, batch);
+      },
+      fn: () => {
+        for (let i = 0; i < n; i++) {
+          leveldb.dbGet(db, intToBytes(i, 4, "le"));
+        }
+      },
+    });
+
+    bench({
+      id: `iterate ${n} entries`,
+      before: () => {
+        const val = new Uint8Array(1000);
+        const batch = [];
+        for (let i = 0; i < n; i++) {
+          batch.push({key: intToBytes(i, 4, "le"), value: val});
+        }
+        leveldb.dbWrite(db, batch);
+      },
+      fn: () => {
+        const iter = leveldb.dbIterator(db);
+        leveldb.iteratorSeekToFirst(iter);
+        for (let i = 0; i < n; i++) {
+          leveldb.iteratorKey(iter);
+          leveldb.iteratorNext(iter);
+        }
+        leveldb.iteratorDestroy(iter);
+      },
+    });
+  }
 });


### PR DESCRIPTION
Add benchmarks for get/set/iterate of 1/10/100/1000/10000 items (key: 4B, value: 1000B)

Results from my local machine:
```
  lmdb
    ✔ set 1 entries                                                       303.3551 ops/s    3.296467 ms/op        -        526 runs   2.24 s
    ✔ get 1 entries                                                       455996.4 ops/s    2.193000 us/op        -     950990 runs   2.52 s
    ✔ iterate 1 entries                                                   472366.6 ops/s    2.117000 us/op        -     788945 runs   2.02 s
    ✔ set 10 entries                                                      261.1657 ops/s    3.828987 ms/op        -        402 runs   2.04 s
    ✔ get 10 entries                                                      85178.88 ops/s    11.74000 us/op        -      47526 runs  0.606 s
    ✔ iterate 10 entries                                                  105485.2 ops/s    9.480000 us/op        -     746893 runs   5.89 s
    ✔ set 100 entries                                                     159.7885 ops/s    6.258274 ms/op        -        135 runs   1.35 s
    ✔ get 100 entries                                                     10089.60 ops/s    99.11200 us/op        -       8122 runs  0.913 s
    ✔ iterate 100 entries                                                 17024.17 ops/s    58.74000 us/op        -      10420 runs  0.710 s
    ✔ set 1000 entries                                                    79.32017 ops/s    12.60713 ms/op        -        102 runs   1.79 s
    ✔ get 1000 entries                                                    954.6312 ops/s    1.047525 ms/op        -        195 runs  0.718 s
    ✔ iterate 1000 entries                                                1722.700 ops/s    580.4840 us/op        -       1744 runs   1.53 s
    ✔ set 10000 entries                                                   12.79674 ops/s    78.14491 ms/op        -         13 runs   1.55 s
    ✔ get 10000 entries                                                   78.12965 ops/s    12.79924 ms/op        -         35 runs   1.04 s
    ✔ iterate 10000 entries                                               137.6237 ops/s    7.266191 ms/op        -        145 runs   1.63 s
```
```
  leveldb
    ✔ set 1 entries                                                       59136.61 ops/s    16.91000 us/op        -     131846 runs   2.42 s
    ✔ batch set 1 entries                                                 57323.02 ops/s    17.44500 us/op        -     249585 runs   4.75 s
    ✔ get 1 entries                                                       209775.5 ops/s    4.767000 us/op        -    2604488 runs   10.0 s
    ✔ iterate 1 entries                                                   436.8764 ops/s    2.288977 ms/op        -        133 runs  0.807 s
    ✔ set 10 entries                                                      5942.018 ops/s    168.2930 us/op        -       3554 runs  0.771 s
    ✔ batch set 10 entries                                                5790.723 ops/s    172.6900 us/op        -      12857 runs   2.43 s
    ✔ get 10 entries                                                      32638.14 ops/s    30.63900 us/op        -      27746 runs  0.909 s
    ✔ iterate 10 entries                                                  26102.16 ops/s    38.31100 us/op        -       7788 runs  0.741 s
    ✔ set 100 entries                                                     546.0089 ops/s    1.831472 ms/op        -       2943 runs   5.94 s
    ✔ batch set 100 entries                                               589.8362 ops/s    1.695386 ms/op        -       1689 runs   3.38 s
    ✔ get 100 entries                                                     2549.440 ops/s    392.2430 us/op        -       1028 runs  0.818 s
    ✔ iterate 100 entries                                                 1908.594 ops/s    523.9460 us/op        -        385 runs  0.704 s
    ✔ set 1000 entries                                                    52.22410 ops/s    19.14825 ms/op        -        251 runs   5.31 s
    ✔ batch set 1000 entries                                              60.13935 ops/s    16.62805 ms/op        -        486 runs   8.60 s
    ✔ get 1000 entries                                                    212.7374 ops/s    4.700630 ms/op        -        110 runs   1.03 s
    ✔ iterate 1000 entries                                                280.3583 ops/s    3.566864 ms/op        -        145 runs   1.03 s
    ✔ set 10000 entries                                                   3.467019 ops/s    288.4323 ms/op        -         37 runs   11.3 s
    ✔ batch set 10000 entries                                             6.063261 ops/s    164.9278 ms/op        -         62 runs   10.8 s
    ✔ get 10000 entries                                                   19.19559 ops/s    52.09529 ms/op        -         30 runs   3.12 s
    ✔ iterate 10000 entries                                               18.73430 ops/s    53.37803 ms/op        -         11 runs   1.19 s
```