### PR TITLE
chore: more leveldb tweaks

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("zig/root.zig"),
         .target = target,
         .optimize = optimize,
+        .pic = true,
     });
     b.modules.put(b.dupe("lodestar_z_bun"), module_lodestar_z_bun) catch @panic("OOM");
 

--- a/src/binding.ts
+++ b/src/binding.ts
@@ -201,21 +201,17 @@ const fns = {
     ],
     "returns": "ptr"
   },
-  "leveldb_set_len_ptr": {
-    "args": [
-      "ptr"
-    ],
-    "returns": "void"
+  "leveldb_get_len_ptr": {
+    "args": [],
+    "returns": "ptr"
   },
-  "leveldb_set_err_ptr": {
-    "args": [
-      "ptr"
-    ],
-    "returns": "void"
+  "leveldb_get_err_ptr": {
+    "args": [],
+    "returns": "ptr"
   },
   "leveldb_free_": {
     "args": [
-      "ptr"
+      "u64"
     ],
     "returns": "void"
   },

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -32,6 +32,7 @@
                     .leveldb,
                     "ssz:persistent_merkle_tree",
                 },
+                .pic = true,
             },
             .linkage = .dynamic,
         },


### PR DESCRIPTION
- use PIC (position independent code) (not sure if its needed, but I saw an error once related to this)
- store the len and error memory on the zig/native side of the binding (this was an error seen in lodestar where updates to the len weren't synchronized properly using the previous implementation)
- simplify handling of memory returned from leveldb (just make a copy and free the original) rather than relying on a finalizer (we can attempt something smarter once we get it working better)