### PR TITLE
chore: rough demo of promise usage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .pic = true,
     });
+    module_lodestar_z_bun.addIncludePath(b.path("include"));
     b.modules.put(b.dupe("lodestar_z_bun"), module_lodestar_z_bun) catch @panic("OOM");
 
     const lib_lodestar_z_bun = b.addLibrary(.{

--- a/include/js_native_api.h
+++ b/include/js_native_api.h
@@ -1,0 +1,615 @@
+#ifndef SRC_JS_NATIVE_API_H_
+#define SRC_JS_NATIVE_API_H_
+
+// This file needs to be compatible with C compilers.
+#include <stdbool.h>  // NOLINT(modernize-deprecated-headers)
+#include <stddef.h>   // NOLINT(modernize-deprecated-headers)
+
+// Use INT_MAX, this should only be consumed by the pre-processor anyway.
+#define NAPI_VERSION_EXPERIMENTAL 2147483647
+#ifndef NAPI_VERSION
+#ifdef NAPI_EXPERIMENTAL
+#define NAPI_VERSION NAPI_VERSION_EXPERIMENTAL
+#else
+// The baseline version for N-API.
+// The NAPI_VERSION controls which version will be used by default when
+// compilling a native addon. If the addon developer specifically wants to use
+// functions available in a new version of N-API that is not yet ported in all
+// LTS versions, they can set NAPI_VERSION knowing that they have specifically
+// depended on that version.
+#define NAPI_VERSION 8
+#endif
+#endif
+
+#include "js_native_api_types.h"
+
+// If you need __declspec(dllimport), either include <node_api.h> instead, or
+// define NAPI_EXTERN as __declspec(dllimport) on the compiler's command line.
+#ifndef NAPI_EXTERN
+#ifdef _WIN32
+#define NAPI_EXTERN __declspec(dllexport)
+#elif defined(__wasm__)
+#define NAPI_EXTERN                                                            \
+  __attribute__((visibility("default")))                                       \
+  __attribute__((__import_module__("napi")))
+#else
+#define NAPI_EXTERN __attribute__((visibility("default")))
+#endif
+#endif
+
+#define NAPI_AUTO_LENGTH SIZE_MAX
+
+#ifdef __cplusplus
+#define EXTERN_C_START extern "C" {
+#define EXTERN_C_END }
+#else
+#define EXTERN_C_START
+#define EXTERN_C_END
+#endif
+
+EXTERN_C_START
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_last_error_info(
+    node_api_basic_env env, const napi_extended_error_info** result);
+
+// Getters for defined singletons
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_undefined(napi_env env,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_null(napi_env env,
+                                                 napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_global(napi_env env,
+                                                   napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_boolean(napi_env env,
+                                                    bool value,
+                                                    napi_value* result);
+
+// Methods to create Primitive types/Objects
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_object(napi_env env,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_array(napi_env env,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_array_with_length(napi_env env, size_t length, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_double(napi_env env,
+                                                      double value,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_int32(napi_env env,
+                                                     int32_t value,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_uint32(napi_env env,
+                                                      uint32_t value,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_int64(napi_env env,
+                                                     int64_t value,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_latin1(
+    napi_env env, const char* str, size_t length, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_utf8(napi_env env,
+                                                           const char* str,
+                                                           size_t length,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_utf16(napi_env env,
+                                                            const char16_t* str,
+                                                            size_t length,
+                                                            napi_value* result);
+#if NAPI_VERSION >= 10
+NAPI_EXTERN napi_status NAPI_CDECL node_api_create_external_string_latin1(
+    napi_env env,
+    char* str,
+    size_t length,
+    node_api_basic_finalize finalize_callback,
+    void* finalize_hint,
+    napi_value* result,
+    bool* copied);
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_create_external_string_utf16(napi_env env,
+                                      char16_t* str,
+                                      size_t length,
+                                      node_api_basic_finalize finalize_callback,
+                                      void* finalize_hint,
+                                      napi_value* result,
+                                      bool* copied);
+
+NAPI_EXTERN napi_status NAPI_CDECL node_api_create_property_key_latin1(
+    napi_env env, const char* str, size_t length, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL node_api_create_property_key_utf8(
+    napi_env env, const char* str, size_t length, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL node_api_create_property_key_utf16(
+    napi_env env, const char16_t* str, size_t length, napi_value* result);
+#endif  // NAPI_VERSION >= 10
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_symbol(napi_env env,
+                                                      napi_value description,
+                                                      napi_value* result);
+#if NAPI_VERSION >= 9
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_symbol_for(napi_env env,
+                    const char* utf8description,
+                    size_t length,
+                    napi_value* result);
+#endif  // NAPI_VERSION >= 9
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_function(napi_env env,
+                                                        const char* utf8name,
+                                                        size_t length,
+                                                        napi_callback cb,
+                                                        void* data,
+                                                        napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_error(napi_env env,
+                                                     napi_value code,
+                                                     napi_value msg,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_type_error(napi_env env,
+                                                          napi_value code,
+                                                          napi_value msg,
+                                                          napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_range_error(napi_env env,
+                                                           napi_value code,
+                                                           napi_value msg,
+                                                           napi_value* result);
+#if NAPI_VERSION >= 9
+NAPI_EXTERN napi_status NAPI_CDECL node_api_create_syntax_error(
+    napi_env env, napi_value code, napi_value msg, napi_value* result);
+#endif  // NAPI_VERSION >= 9
+
+// Methods to get the native napi_value from Primitive type
+NAPI_EXTERN napi_status NAPI_CDECL napi_typeof(napi_env env,
+                                               napi_value value,
+                                               napi_valuetype* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_double(napi_env env,
+                                                         napi_value value,
+                                                         double* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_int32(napi_env env,
+                                                        napi_value value,
+                                                        int32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_uint32(napi_env env,
+                                                         napi_value value,
+                                                         uint32_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_int64(napi_env env,
+                                                        napi_value value,
+                                                        int64_t* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_bool(napi_env env,
+                                                       napi_value value,
+                                                       bool* result);
+
+// Copies LATIN-1 encoded bytes from a string into a buffer.
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_string_latin1(
+    napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result);
+
+// Copies UTF-8 encoded bytes from a string into a buffer.
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_string_utf8(
+    napi_env env, napi_value value, char* buf, size_t bufsize, size_t* result);
+
+// Copies UTF-16 encoded bytes from a string into a buffer.
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_string_utf16(napi_env env,
+                                                               napi_value value,
+                                                               char16_t* buf,
+                                                               size_t bufsize,
+                                                               size_t* result);
+
+// Methods to coerce values
+// These APIs may execute user scripts
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_bool(napi_env env,
+                                                       napi_value value,
+                                                       napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_number(napi_env env,
+                                                         napi_value value,
+                                                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_object(napi_env env,
+                                                         napi_value value,
+                                                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_coerce_to_string(napi_env env,
+                                                         napi_value value,
+                                                         napi_value* result);
+
+// Methods to work with Objects
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_prototype(napi_env env,
+                                                      napi_value object,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_property_names(napi_env env,
+                                                           napi_value object,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_set_property(napi_env env,
+                                                     napi_value object,
+                                                     napi_value key,
+                                                     napi_value value);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_property(napi_env env,
+                                                     napi_value object,
+                                                     napi_value key,
+                                                     bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_property(napi_env env,
+                                                     napi_value object,
+                                                     napi_value key,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_property(napi_env env,
+                                                        napi_value object,
+                                                        napi_value key,
+                                                        bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_own_property(napi_env env,
+                                                         napi_value object,
+                                                         napi_value key,
+                                                         bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_set_named_property(napi_env env,
+                                                           napi_value object,
+                                                           const char* utf8name,
+                                                           napi_value value);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_named_property(napi_env env,
+                                                           napi_value object,
+                                                           const char* utf8name,
+                                                           bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_named_property(napi_env env,
+                                                           napi_value object,
+                                                           const char* utf8name,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_set_element(napi_env env,
+                                                    napi_value object,
+                                                    uint32_t index,
+                                                    napi_value value);
+NAPI_EXTERN napi_status NAPI_CDECL napi_has_element(napi_env env,
+                                                    napi_value object,
+                                                    uint32_t index,
+                                                    bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_element(napi_env env,
+                                                    napi_value object,
+                                                    uint32_t index,
+                                                    napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_element(napi_env env,
+                                                       napi_value object,
+                                                       uint32_t index,
+                                                       bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_define_properties(napi_env env,
+                       napi_value object,
+                       size_t property_count,
+                       const napi_property_descriptor* properties);
+
+// Methods to work with Arrays
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_array(napi_env env,
+                                                 napi_value value,
+                                                 bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_array_length(napi_env env,
+                                                         napi_value value,
+                                                         uint32_t* result);
+
+// Methods to compare values
+NAPI_EXTERN napi_status NAPI_CDECL napi_strict_equals(napi_env env,
+                                                      napi_value lhs,
+                                                      napi_value rhs,
+                                                      bool* result);
+
+// Methods to work with Functions
+NAPI_EXTERN napi_status NAPI_CDECL napi_call_function(napi_env env,
+                                                      napi_value recv,
+                                                      napi_value func,
+                                                      size_t argc,
+                                                      const napi_value* argv,
+                                                      napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_new_instance(napi_env env,
+                                                     napi_value constructor,
+                                                     size_t argc,
+                                                     const napi_value* argv,
+                                                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_instanceof(napi_env env,
+                                                   napi_value object,
+                                                   napi_value constructor,
+                                                   bool* result);
+
+// Methods to work with napi_callbacks
+
+// Gets all callback info in a single call. (Ugly, but faster.)
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_cb_info(
+    napi_env env,               // [in] Node-API environment handle
+    napi_callback_info cbinfo,  // [in] Opaque callback-info handle
+    size_t* argc,      // [in-out] Specifies the size of the provided argv array
+                       // and receives the actual count of args.
+    napi_value* argv,  // [out] Array of values
+    napi_value* this_arg,  // [out] Receives the JS 'this' arg for the call
+    void** data);          // [out] Receives the data pointer for the callback.
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_new_target(
+    napi_env env, napi_callback_info cbinfo, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_define_class(napi_env env,
+                  const char* utf8name,
+                  size_t length,
+                  napi_callback constructor,
+                  void* data,
+                  size_t property_count,
+                  const napi_property_descriptor* properties,
+                  napi_value* result);
+
+// Methods to work with external data objects
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_wrap(napi_env env,
+          napi_value js_object,
+          void* native_object,
+          node_api_basic_finalize finalize_cb,
+          void* finalize_hint,
+          napi_ref* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_unwrap(napi_env env,
+                                               napi_value js_object,
+                                               void** result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_remove_wrap(napi_env env,
+                                                    napi_value js_object,
+                                                    void** result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_external(napi_env env,
+                     void* data,
+                     node_api_basic_finalize finalize_cb,
+                     void* finalize_hint,
+                     napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_external(napi_env env,
+                                                           napi_value value,
+                                                           void** result);
+
+// Methods to control object lifespan
+
+// Set initial_refcount to 0 for a weak reference, >0 for a strong reference.
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_reference(napi_env env,
+                      napi_value value,
+                      uint32_t initial_refcount,
+                      napi_ref* result);
+
+// Deletes a reference. The referenced value is released, and may
+// be GC'd unless there are other references to it.
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_reference(napi_env env,
+                                                         napi_ref ref);
+
+// Increments the reference count, optionally returning the resulting count.
+// After this call the  reference will be a strong reference because its
+// refcount is >0, and the referenced object is effectively "pinned".
+// Calling this when the refcount is 0 and the object is unavailable
+// results in an error.
+NAPI_EXTERN napi_status NAPI_CDECL napi_reference_ref(napi_env env,
+                                                      napi_ref ref,
+                                                      uint32_t* result);
+
+// Decrements the reference count, optionally returning the resulting count.
+// If the result is 0 the reference is now weak and the object may be GC'd
+// at any time if there are no other references. Calling this when the
+// refcount is already 0 results in an error.
+NAPI_EXTERN napi_status NAPI_CDECL napi_reference_unref(napi_env env,
+                                                        napi_ref ref,
+                                                        uint32_t* result);
+
+// Attempts to get a referenced value. If the reference is weak,
+// the value might no longer be available, in that case the call
+// is still successful but the result is NULL.
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_reference_value(napi_env env,
+                                                            napi_ref ref,
+                                                            napi_value* result);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_open_handle_scope(napi_env env, napi_handle_scope* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_close_handle_scope(napi_env env, napi_handle_scope scope);
+NAPI_EXTERN napi_status NAPI_CDECL napi_open_escapable_handle_scope(
+    napi_env env, napi_escapable_handle_scope* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_close_escapable_handle_scope(
+    napi_env env, napi_escapable_handle_scope scope);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_escape_handle(napi_env env,
+                   napi_escapable_handle_scope scope,
+                   napi_value escapee,
+                   napi_value* result);
+
+// Methods to support error handling
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw(napi_env env, napi_value error);
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw_error(napi_env env,
+                                                    const char* code,
+                                                    const char* msg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw_type_error(napi_env env,
+                                                         const char* code,
+                                                         const char* msg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_throw_range_error(napi_env env,
+                                                          const char* code,
+                                                          const char* msg);
+#if NAPI_VERSION >= 9
+NAPI_EXTERN napi_status NAPI_CDECL node_api_throw_syntax_error(napi_env env,
+                                                               const char* code,
+                                                               const char* msg);
+#endif  // NAPI_VERSION >= 9
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_error(napi_env env,
+                                                 napi_value value,
+                                                 bool* result);
+
+// Methods to support catching exceptions
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_exception_pending(napi_env env,
+                                                             bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_and_clear_last_exception(napi_env env, napi_value* result);
+
+// Methods to work with array buffers and typed arrays
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_arraybuffer(napi_env env,
+                                                       napi_value value,
+                                                       bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_arraybuffer(napi_env env,
+                                                           size_t byte_length,
+                                                           void** data,
+                                                           napi_value* result);
+#ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_external_arraybuffer(napi_env env,
+                                 void* external_data,
+                                 size_t byte_length,
+                                 node_api_basic_finalize finalize_cb,
+                                 void* finalize_hint,
+                                 napi_value* result);
+#endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_arraybuffer_info(
+    napi_env env, napi_value arraybuffer, void** data, size_t* byte_length);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_typedarray(napi_env env,
+                                                      napi_value value,
+                                                      bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_typedarray(napi_env env,
+                       napi_typedarray_type type,
+                       size_t length,
+                       napi_value arraybuffer,
+                       size_t byte_offset,
+                       napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_typedarray_info(napi_env env,
+                         napi_value typedarray,
+                         napi_typedarray_type* type,
+                         size_t* length,
+                         void** data,
+                         napi_value* arraybuffer,
+                         size_t* byte_offset);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_dataview(napi_env env,
+                                                        size_t length,
+                                                        napi_value arraybuffer,
+                                                        size_t byte_offset,
+                                                        napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_dataview(napi_env env,
+                                                    napi_value value,
+                                                    bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_dataview_info(napi_env env,
+                       napi_value dataview,
+                       size_t* bytelength,
+                       void** data,
+                       napi_value* arraybuffer,
+                       size_t* byte_offset);
+
+// version management
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_version(node_api_basic_env env,
+                                                    uint32_t* result);
+
+// Promises
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_promise(napi_env env,
+                                                       napi_deferred* deferred,
+                                                       napi_value* promise);
+NAPI_EXTERN napi_status NAPI_CDECL napi_resolve_deferred(napi_env env,
+                                                         napi_deferred deferred,
+                                                         napi_value resolution);
+NAPI_EXTERN napi_status NAPI_CDECL napi_reject_deferred(napi_env env,
+                                                        napi_deferred deferred,
+                                                        napi_value rejection);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_promise(napi_env env,
+                                                   napi_value value,
+                                                   bool* is_promise);
+
+// Running a script
+NAPI_EXTERN napi_status NAPI_CDECL napi_run_script(napi_env env,
+                                                   napi_value script,
+                                                   napi_value* result);
+
+// Memory management
+NAPI_EXTERN napi_status NAPI_CDECL napi_adjust_external_memory(
+    node_api_basic_env env, int64_t change_in_bytes, int64_t* adjusted_value);
+
+#if NAPI_VERSION >= 5
+
+// Dates
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_date(napi_env env,
+                                                    double time,
+                                                    napi_value* result);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_date(napi_env env,
+                                                napi_value value,
+                                                bool* is_date);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_date_value(napi_env env,
+                                                       napi_value value,
+                                                       double* result);
+
+// Add finalizer for pointer
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_add_finalizer(napi_env env,
+                   napi_value js_object,
+                   void* finalize_data,
+                   node_api_basic_finalize finalize_cb,
+                   void* finalize_hint,
+                   napi_ref* result);
+
+#endif  // NAPI_VERSION >= 5
+
+#ifdef NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_HAS_POST_FINALIZER
+
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_post_finalizer(node_api_basic_env env,
+                        napi_finalize finalize_cb,
+                        void* finalize_data,
+                        void* finalize_hint);
+
+#endif  // NAPI_EXPERIMENTAL
+
+#if NAPI_VERSION >= 6
+
+// BigInt
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_bigint_int64(napi_env env,
+                                                            int64_t value,
+                                                            napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_bigint_uint64(napi_env env, uint64_t value, napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_bigint_words(napi_env env,
+                         int sign_bit,
+                         size_t word_count,
+                         const uint64_t* words,
+                         napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_bigint_int64(napi_env env,
+                                                               napi_value value,
+                                                               int64_t* result,
+                                                               bool* lossless);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_bigint_uint64(
+    napi_env env, napi_value value, uint64_t* result, bool* lossless);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_value_bigint_words(napi_env env,
+                            napi_value value,
+                            int* sign_bit,
+                            size_t* word_count,
+                            uint64_t* words);
+
+// Object
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_all_property_names(napi_env env,
+                            napi_value object,
+                            napi_key_collection_mode key_mode,
+                            napi_key_filter key_filter,
+                            napi_key_conversion key_conversion,
+                            napi_value* result);
+
+// Instance data
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_set_instance_data(node_api_basic_env env,
+                       void* data,
+                       napi_finalize finalize_cb,
+                       void* finalize_hint);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_instance_data(node_api_basic_env env, void** data);
+#endif  // NAPI_VERSION >= 6
+
+#if NAPI_VERSION >= 7
+// ArrayBuffer detaching
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_detach_arraybuffer(napi_env env, napi_value arraybuffer);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_is_detached_arraybuffer(napi_env env, napi_value value, bool* result);
+#endif  // NAPI_VERSION >= 7
+
+#if NAPI_VERSION >= 8
+// Type tagging
+NAPI_EXTERN napi_status NAPI_CDECL napi_type_tag_object(
+    napi_env env, napi_value value, const napi_type_tag* type_tag);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_check_object_type_tag(napi_env env,
+                           napi_value value,
+                           const napi_type_tag* type_tag,
+                           bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_object_freeze(napi_env env,
+                                                      napi_value object);
+NAPI_EXTERN napi_status NAPI_CDECL napi_object_seal(napi_env env,
+                                                    napi_value object);
+#endif  // NAPI_VERSION >= 8
+
+EXTERN_C_END
+
+#endif  // SRC_JS_NATIVE_API_H_

--- a/include/js_native_api_types.h
+++ b/include/js_native_api_types.h
@@ -1,0 +1,211 @@
+#ifndef SRC_JS_NATIVE_API_TYPES_H_
+#define SRC_JS_NATIVE_API_TYPES_H_
+
+// This file needs to be compatible with C compilers.
+// This is a public include file, and these includes have essentially
+// became part of it's API.
+#include <stddef.h>  // NOLINT(modernize-deprecated-headers)
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers)
+
+#if !defined __cplusplus || (defined(_MSC_VER) && _MSC_VER < 1900)
+typedef uint16_t char16_t;
+#endif
+
+#ifndef NAPI_CDECL
+#ifdef _WIN32
+#define NAPI_CDECL __cdecl
+#else
+#define NAPI_CDECL
+#endif
+#endif
+
+// JSVM API types are all opaque pointers for ABI stability
+// typedef undefined structs instead of void* for compile time type safety
+typedef struct napi_env__* napi_env;
+
+// We need to mark APIs which can be called during garbage collection (GC),
+// meaning that they do not affect the state of the JS engine, and can
+// therefore be called synchronously from a finalizer that itself runs
+// synchronously during GC. Such APIs can receive either a `napi_env` or a
+// `node_api_basic_env` as their first parameter, because we should be able to
+// also call them during normal, non-garbage-collecting operations, whereas
+// APIs that affect the state of the JS engine can only receive a `napi_env` as
+// their first parameter, because we must not call them during GC. In lieu of
+// inheritance, we use the properties of the const qualifier to accomplish
+// this, because both a const and a non-const value can be passed to an API
+// expecting a const value, but only a non-const value can be passed to an API
+// expecting a non-const value.
+//
+// In conjunction with appropriate CFLAGS to warn us if we're passing a const
+// (basic) environment into an API that expects a non-const environment, and
+// the definition of basic finalizer function pointer types below, which
+// receive a basic environment as their first parameter, and can thus only call
+// basic APIs (unless the user explicitly casts the environment), we achieve
+// the ability to ensure at compile time that we do not call APIs that affect
+// the state of the JS engine from a synchronous (basic) finalizer.
+#if !defined(NAPI_EXPERIMENTAL) ||                                             \
+    (defined(NAPI_EXPERIMENTAL) &&                                             \
+     (defined(NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT) ||                       \
+      defined(NODE_API_EXPERIMENTAL_BASIC_ENV_OPT_OUT)))
+typedef struct napi_env__* node_api_nogc_env;
+#else
+typedef const struct napi_env__* node_api_nogc_env;
+#endif
+typedef node_api_nogc_env node_api_basic_env;
+
+typedef struct napi_value__* napi_value;
+typedef struct napi_ref__* napi_ref;
+typedef struct napi_handle_scope__* napi_handle_scope;
+typedef struct napi_escapable_handle_scope__* napi_escapable_handle_scope;
+typedef struct napi_callback_info__* napi_callback_info;
+typedef struct napi_deferred__* napi_deferred;
+
+typedef enum {
+  napi_default = 0,
+  napi_writable = 1 << 0,
+  napi_enumerable = 1 << 1,
+  napi_configurable = 1 << 2,
+
+  // Used with napi_define_class to distinguish static properties
+  // from instance properties. Ignored by napi_define_properties.
+  napi_static = 1 << 10,
+
+#if NAPI_VERSION >= 8
+  // Default for class methods.
+  napi_default_method = napi_writable | napi_configurable,
+
+  // Default for object properties, like in JS obj[prop].
+  napi_default_jsproperty = napi_writable | napi_enumerable | napi_configurable,
+#endif  // NAPI_VERSION >= 8
+} napi_property_attributes;
+
+typedef enum {
+  // ES6 types (corresponds to typeof)
+  napi_undefined,
+  napi_null,
+  napi_boolean,
+  napi_number,
+  napi_string,
+  napi_symbol,
+  napi_object,
+  napi_function,
+  napi_external,
+  napi_bigint,
+} napi_valuetype;
+
+typedef enum {
+  napi_int8_array,
+  napi_uint8_array,
+  napi_uint8_clamped_array,
+  napi_int16_array,
+  napi_uint16_array,
+  napi_int32_array,
+  napi_uint32_array,
+  napi_float32_array,
+  napi_float64_array,
+  napi_bigint64_array,
+  napi_biguint64_array,
+} napi_typedarray_type;
+
+typedef enum {
+  napi_ok,
+  napi_invalid_arg,
+  napi_object_expected,
+  napi_string_expected,
+  napi_name_expected,
+  napi_function_expected,
+  napi_number_expected,
+  napi_boolean_expected,
+  napi_array_expected,
+  napi_generic_failure,
+  napi_pending_exception,
+  napi_cancelled,
+  napi_escape_called_twice,
+  napi_handle_scope_mismatch,
+  napi_callback_scope_mismatch,
+  napi_queue_full,
+  napi_closing,
+  napi_bigint_expected,
+  napi_date_expected,
+  napi_arraybuffer_expected,
+  napi_detachable_arraybuffer_expected,
+  napi_would_deadlock,  // unused
+  napi_no_external_buffers_allowed,
+  napi_cannot_run_js,
+} napi_status;
+// Note: when adding a new enum value to `napi_status`, please also update
+//   * `const int last_status` in the definition of `napi_get_last_error_info()'
+//     in file js_native_api_v8.cc.
+//   * `const char* error_messages[]` in file js_native_api_v8.cc with a brief
+//     message explaining the error.
+//   * the definition of `napi_status` in doc/api/n-api.md to reflect the newly
+//     added value(s).
+
+typedef napi_value(NAPI_CDECL* napi_callback)(napi_env env,
+                                              napi_callback_info info);
+typedef void(NAPI_CDECL* napi_finalize)(napi_env env,
+                                        void* finalize_data,
+                                        void* finalize_hint);
+
+#if !defined(NAPI_EXPERIMENTAL) ||                                             \
+    (defined(NAPI_EXPERIMENTAL) &&                                             \
+     (defined(NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT) ||                       \
+      defined(NODE_API_EXPERIMENTAL_BASIC_ENV_OPT_OUT)))
+typedef napi_finalize node_api_nogc_finalize;
+#else
+typedef void(NAPI_CDECL* node_api_nogc_finalize)(node_api_nogc_env env,
+                                                 void* finalize_data,
+                                                 void* finalize_hint);
+#endif
+typedef node_api_nogc_finalize node_api_basic_finalize;
+
+typedef struct {
+  // One of utf8name or name should be NULL.
+  const char* utf8name;
+  napi_value name;
+
+  napi_callback method;
+  napi_callback getter;
+  napi_callback setter;
+  napi_value value;
+
+  napi_property_attributes attributes;
+  void* data;
+} napi_property_descriptor;
+
+typedef struct {
+  const char* error_message;
+  void* engine_reserved;
+  uint32_t engine_error_code;
+  napi_status error_code;
+} napi_extended_error_info;
+
+#if NAPI_VERSION >= 6
+typedef enum {
+  napi_key_include_prototypes,
+  napi_key_own_only
+} napi_key_collection_mode;
+
+typedef enum {
+  napi_key_all_properties = 0,
+  napi_key_writable = 1,
+  napi_key_enumerable = 1 << 1,
+  napi_key_configurable = 1 << 2,
+  napi_key_skip_strings = 1 << 3,
+  napi_key_skip_symbols = 1 << 4
+} napi_key_filter;
+
+typedef enum {
+  napi_key_keep_numbers,
+  napi_key_numbers_to_strings
+} napi_key_conversion;
+#endif  // NAPI_VERSION >= 6
+
+#if NAPI_VERSION >= 8
+typedef struct {
+  uint64_t lower;
+  uint64_t upper;
+} napi_type_tag;
+#endif  // NAPI_VERSION >= 8
+
+#endif  // SRC_JS_NATIVE_API_TYPES_H_

--- a/include/node_api.h
+++ b/include/node_api.h
@@ -1,0 +1,269 @@
+#ifndef SRC_NODE_API_H_
+#define SRC_NODE_API_H_
+
+#if defined(BUILDING_NODE_EXTENSION) && !defined(NAPI_EXTERN)
+#ifdef _WIN32
+// Building native addon against node
+#define NAPI_EXTERN __declspec(dllimport)
+#elif defined(__wasm__)
+#define NAPI_EXTERN __attribute__((__import_module__("napi")))
+#endif
+#endif
+#include "js_native_api.h"
+#include "node_api_types.h"
+
+struct uv_loop_s;  // Forward declaration.
+
+#ifdef _WIN32
+#define NAPI_MODULE_EXPORT __declspec(dllexport)
+#else
+#ifdef __EMSCRIPTEN__
+#define NAPI_MODULE_EXPORT                                                     \
+  __attribute__((visibility("default"))) __attribute__((used))
+#else
+#define NAPI_MODULE_EXPORT __attribute__((visibility("default")))
+#endif
+#endif
+
+#if defined(__GNUC__)
+#define NAPI_NO_RETURN __attribute__((noreturn))
+#elif defined(_WIN32)
+#define NAPI_NO_RETURN __declspec(noreturn)
+#else
+#define NAPI_NO_RETURN
+#endif
+
+typedef napi_value(NAPI_CDECL* napi_addon_register_func)(napi_env env,
+                                                         napi_value exports);
+typedef int32_t(NAPI_CDECL* node_api_addon_get_api_version_func)(void);
+
+// Used by deprecated registration method napi_module_register.
+typedef struct napi_module {
+  int nm_version;
+  unsigned int nm_flags;
+  const char* nm_filename;
+  napi_addon_register_func nm_register_func;
+  const char* nm_modname;
+  void* nm_priv;
+  void* reserved[4];
+} napi_module;
+
+#define NAPI_MODULE_VERSION 1
+
+#define NAPI_MODULE_INITIALIZER_X(base, version)                               \
+  NAPI_MODULE_INITIALIZER_X_HELPER(base, version)
+#define NAPI_MODULE_INITIALIZER_X_HELPER(base, version) base##version
+
+#ifdef __wasm__
+#define NAPI_MODULE_INITIALIZER_BASE napi_register_wasm_v
+#else
+#define NAPI_MODULE_INITIALIZER_BASE napi_register_module_v
+#endif
+
+#define NODE_API_MODULE_GET_API_VERSION_BASE node_api_module_get_api_version_v
+
+#define NAPI_MODULE_INITIALIZER                                                \
+  NAPI_MODULE_INITIALIZER_X(NAPI_MODULE_INITIALIZER_BASE, NAPI_MODULE_VERSION)
+
+#define NODE_API_MODULE_GET_API_VERSION                                        \
+  NAPI_MODULE_INITIALIZER_X(NODE_API_MODULE_GET_API_VERSION_BASE,              \
+                            NAPI_MODULE_VERSION)
+
+#define NAPI_MODULE_INIT()                                                     \
+  EXTERN_C_START                                                               \
+  NAPI_MODULE_EXPORT int32_t NODE_API_MODULE_GET_API_VERSION(void) {           \
+    return NAPI_VERSION;                                                       \
+  }                                                                            \
+  NAPI_MODULE_EXPORT napi_value NAPI_MODULE_INITIALIZER(napi_env env,          \
+                                                        napi_value exports);   \
+  EXTERN_C_END                                                                 \
+  napi_value NAPI_MODULE_INITIALIZER(napi_env env, napi_value exports)
+
+#define NAPI_MODULE(modname, regfunc)                                          \
+  NAPI_MODULE_INIT() { return regfunc(env, exports); }
+
+// Deprecated. Use NAPI_MODULE.
+#define NAPI_MODULE_X(modname, regfunc, priv, flags)                           \
+  NAPI_MODULE(modname, regfunc)
+
+EXTERN_C_START
+
+// Deprecated. Replaced by symbol-based registration defined by NAPI_MODULE
+// and NAPI_MODULE_INIT macros.
+NAPI_EXTERN void NAPI_CDECL
+napi_module_register(napi_module* mod);
+
+NAPI_EXTERN NAPI_NO_RETURN void NAPI_CDECL
+napi_fatal_error(const char* location,
+                 size_t location_len,
+                 const char* message,
+                 size_t message_len);
+
+// Methods for custom handling of async operations
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_async_init(napi_env env,
+                napi_value async_resource,
+                napi_value async_resource_name,
+                napi_async_context* result);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_async_destroy(napi_env env, napi_async_context async_context);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_make_callback(napi_env env,
+                   napi_async_context async_context,
+                   napi_value recv,
+                   napi_value func,
+                   size_t argc,
+                   const napi_value* argv,
+                   napi_value* result);
+
+// Methods to provide node::Buffer functionality with napi types
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_buffer(napi_env env,
+                                                      size_t length,
+                                                      void** data,
+                                                      napi_value* result);
+#ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_external_buffer(napi_env env,
+                            size_t length,
+                            void* data,
+                            node_api_basic_finalize finalize_cb,
+                            void* finalize_hint,
+                            napi_value* result);
+#endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
+
+#if NAPI_VERSION >= 10
+
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_create_buffer_from_arraybuffer(napi_env env,
+                                        napi_value arraybuffer,
+                                        size_t byte_offset,
+                                        size_t byte_length,
+                                        napi_value* result);
+#endif  // NAPI_VERSION >= 10
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_create_buffer_copy(napi_env env,
+                                                           size_t length,
+                                                           const void* data,
+                                                           void** result_data,
+                                                           napi_value* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_is_buffer(napi_env env,
+                                                  napi_value value,
+                                                  bool* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
+                                                        napi_value value,
+                                                        void** data,
+                                                        size_t* length);
+
+// Methods to manage simple async operations
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_async_work(napi_env env,
+                       napi_value async_resource,
+                       napi_value async_resource_name,
+                       napi_async_execute_callback execute,
+                       napi_async_complete_callback complete,
+                       void* data,
+                       napi_async_work* result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_async_work(napi_env env,
+                                                          napi_async_work work);
+NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(node_api_basic_env env,
+                                                         napi_async_work work);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_cancel_async_work(node_api_basic_env env, napi_async_work work);
+
+// version management
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_node_version(
+    node_api_basic_env env, const napi_node_version** version);
+
+#if NAPI_VERSION >= 2
+
+// Return the current libuv event loop for a given environment
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_get_uv_event_loop(node_api_basic_env env, struct uv_loop_s** loop);
+
+#endif  // NAPI_VERSION >= 2
+
+#if NAPI_VERSION >= 3
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_fatal_exception(napi_env env,
+                                                        napi_value err);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_add_env_cleanup_hook(
+    node_api_basic_env env, napi_cleanup_hook fun, void* arg);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_remove_env_cleanup_hook(
+    node_api_basic_env env, napi_cleanup_hook fun, void* arg);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_open_callback_scope(napi_env env,
+                         napi_value resource_object,
+                         napi_async_context context,
+                         napi_callback_scope* result);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_close_callback_scope(napi_env env, napi_callback_scope scope);
+
+#endif  // NAPI_VERSION >= 3
+
+#if NAPI_VERSION >= 4
+
+// Calling into JS from other threads
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_create_threadsafe_function(napi_env env,
+                                napi_value func,
+                                napi_value async_resource,
+                                napi_value async_resource_name,
+                                size_t max_queue_size,
+                                size_t initial_thread_count,
+                                void* thread_finalize_data,
+                                napi_finalize thread_finalize_cb,
+                                void* context,
+                                napi_threadsafe_function_call_js call_js_cb,
+                                napi_threadsafe_function* result);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_threadsafe_function_context(
+    napi_threadsafe_function func, void** result);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_call_threadsafe_function(napi_threadsafe_function func,
+                              void* data,
+                              napi_threadsafe_function_call_mode is_blocking);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_acquire_threadsafe_function(napi_threadsafe_function func);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_release_threadsafe_function(
+    napi_threadsafe_function func, napi_threadsafe_function_release_mode mode);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_unref_threadsafe_function(
+    node_api_basic_env env, napi_threadsafe_function func);
+
+NAPI_EXTERN napi_status NAPI_CDECL napi_ref_threadsafe_function(
+    node_api_basic_env env, napi_threadsafe_function func);
+
+#endif  // NAPI_VERSION >= 4
+
+#if NAPI_VERSION >= 8
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_add_async_cleanup_hook(node_api_basic_env env,
+                            napi_async_cleanup_hook hook,
+                            void* arg,
+                            napi_async_cleanup_hook_handle* remove_handle);
+
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_remove_async_cleanup_hook(napi_async_cleanup_hook_handle remove_handle);
+
+#endif  // NAPI_VERSION >= 8
+
+#if NAPI_VERSION >= 9
+
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_get_module_file_name(node_api_basic_env env, const char** result);
+
+#endif  // NAPI_VERSION >= 9
+
+EXTERN_C_END
+
+#endif  // SRC_NODE_API_H_

--- a/include/node_api_types.h
+++ b/include/node_api_types.h
@@ -1,0 +1,52 @@
+#ifndef SRC_NODE_API_TYPES_H_
+#define SRC_NODE_API_TYPES_H_
+
+#include "js_native_api_types.h"
+
+typedef struct napi_callback_scope__* napi_callback_scope;
+typedef struct napi_async_context__* napi_async_context;
+typedef struct napi_async_work__* napi_async_work;
+
+#if NAPI_VERSION >= 3
+typedef void(NAPI_CDECL* napi_cleanup_hook)(void* arg);
+#endif  // NAPI_VERSION >= 3
+
+#if NAPI_VERSION >= 4
+typedef struct napi_threadsafe_function__* napi_threadsafe_function;
+#endif  // NAPI_VERSION >= 4
+
+#if NAPI_VERSION >= 4
+typedef enum {
+  napi_tsfn_release,
+  napi_tsfn_abort
+} napi_threadsafe_function_release_mode;
+
+typedef enum {
+  napi_tsfn_nonblocking,
+  napi_tsfn_blocking
+} napi_threadsafe_function_call_mode;
+#endif  // NAPI_VERSION >= 4
+
+typedef void(NAPI_CDECL* napi_async_execute_callback)(napi_env env, void* data);
+typedef void(NAPI_CDECL* napi_async_complete_callback)(napi_env env,
+                                                       napi_status status,
+                                                       void* data);
+#if NAPI_VERSION >= 4
+typedef void(NAPI_CDECL* napi_threadsafe_function_call_js)(
+    napi_env env, napi_value js_callback, void* context, void* data);
+#endif  // NAPI_VERSION >= 4
+
+typedef struct {
+  uint32_t major;
+  uint32_t minor;
+  uint32_t patch;
+  const char* release;
+} napi_node_version;
+
+#if NAPI_VERSION >= 8
+typedef struct napi_async_cleanup_hook_handle__* napi_async_cleanup_hook_handle;
+typedef void(NAPI_CDECL* napi_async_cleanup_hook)(
+    napi_async_cleanup_hook_handle handle, void* data);
+#endif  // NAPI_VERSION >= 8
+
+#endif  // SRC_NODE_API_TYPES_H_

--- a/src/binding.ts
+++ b/src/binding.ts
@@ -273,6 +273,15 @@ const fns = {
     ],
     "returns": "ptr"
   },
+  "leveldb_db_get_promise": {
+    "args": [
+      "napi_env",
+      "u64",
+      "ptr",
+      "u32"
+    ],
+    "returns": "napi_value"
+  },
   "leveldb_db_delete": {
     "args": [
       "u64",

--- a/src/leveldb.ts
+++ b/src/leveldb.ts
@@ -77,6 +77,15 @@ export function dbGet(db: DB, key: Uint8Array): Uint8Array | null {
   return value;
 }
 
+export function dbGetPromise(db: DB, key: Uint8Array): Promise<Uint8Array | null> {
+  return binding.leveldb_db_get_promise(
+    null,
+    db,
+    key,
+    key.length,
+  ) as Promise<Uint8Array | null>;
+}
+
 export function dbDelete(db: DB, key: Uint8Array): void {
   throwErr(binding.leveldb_db_delete(
     db,

--- a/test/leveldb.test.ts
+++ b/test/leveldb.test.ts
@@ -126,4 +126,34 @@ describe("leveldb", () => {
     expect(fs.existsSync(nonExistentPath)).toBe(false);
     expect(() => leveldb.dbDestroy(nonExistentPath)).not.toThrow();
   });
+
+  test.only("get promise", async () => {
+    const db = leveldb.dbOpen(dbPath, {create_if_missing: true});
+
+    const key = new Uint8Array([1, 2, 3]);
+    const value = new Uint8Array(Array.from({length: 256}, (_, i) => i));
+
+    leveldb.dbPut(db, key, value);
+    const retrieved = leveldb.dbGet(db, key);
+    expect(retrieved).toEqual(value);
+
+    {
+      const t1 = performance.now();
+      const d = leveldb.dbGetPromise(db, key);
+      const t2 = performance.now();
+      await d;
+      const t3 = performance.now();
+      console.log("async", t2 - t1, t3 - t2);
+    }
+
+    {
+      const t1 = performance.now();
+      leveldb.dbGet(db, key);
+      const t2 = performance.now();
+      console.log("sync", t2 - t1);
+    }
+
+    leveldb.dbClose(db);
+  });
+
 });

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -33,6 +33,7 @@
                     "ssz:persistent_merkle_tree",
                 },
                 .pic = true,
+                .include_paths = .{"include"},
             },
             .linkage = .dynamic,
         },

--- a/zig/napi.zig
+++ b/zig/napi.zig
@@ -1,0 +1,87 @@
+pub const napi = @cImport({
+    @cDefine("NAPI_VERSION", "10");
+    @cInclude("node_api.h");
+});
+
+/// https://nodejs.org/api/n-api.html#napi_status
+pub const Status = enum(napi.napi_status) {
+    ok = napi.napi_ok,
+    invalid_arg = napi.napi_invalid_arg,
+    object_expected = napi.napi_object_expected,
+    string_expected = napi.napi_string_expected,
+    name_expected = napi.napi_name_expected,
+    function_expected = napi.napi_function_expected,
+    number_expected = napi.napi_number_expected,
+    boolean_expected = napi.napi_boolean_expected,
+    array_expected = napi.napi_array_expected,
+    generic_failure = napi.napi_generic_failure,
+    pending_exception = napi.napi_pending_exception,
+    cancelled = napi.napi_cancelled,
+    escape_called_twice = napi.napi_escape_called_twice,
+    handle_scope_mismatch = napi.napi_handle_scope_mismatch,
+    callback_scope_mismatch = napi.napi_callback_scope_mismatch,
+    queue_full = napi.napi_queue_full,
+    closing = napi.napi_closing,
+    bigint_expected = napi.napi_bigint_expected,
+    date_expected = napi.napi_date_expected,
+    arraybuffer_expected = napi.napi_arraybuffer_expected,
+    detachable_arraybuffer_expected = napi.napi_detachable_arraybuffer_expected,
+    would_deadlock = napi.napi_would_deadlock,
+    no_external_buffers_allowed = napi.napi_no_external_buffers_allowed,
+    cannot_run_js = napi.napi_cannot_run_js,
+};
+
+pub const NapiError = error{
+    InvalidArg,
+    ObjectExpected,
+    StringExpected,
+    NameExpected,
+    FunctionExpected,
+    NumberExpected,
+    BooleanExpected,
+    ArrayExpected,
+    GenericFailure,
+    PendingException,
+    Cancelled,
+    EscapeCalledTwice,
+    HandleScopeMismatch,
+    CallbackScopeMismatch,
+    QueueFull,
+    Closing,
+    BigIntExpected,
+    DateExpected,
+    ArrayBufferExpected,
+    DetachableArrayBufferExpected,
+    WouldDeadlock,
+    NoExternalBuffersAllowed,
+    CannotRunJS,
+};
+
+pub fn toError(code: c_uint) NapiError {
+    switch (@as(Status, @enumFromInt(code))) {
+        .ok => unreachable,
+        .invalid_arg => return error.InvalidArg,
+        .object_expected => return error.ObjectExpected,
+        .string_expected => return error.StringExpected,
+        .name_expected => return error.NameExpected,
+        .function_expected => return error.FunctionExpected,
+        .number_expected => return error.NumberExpected,
+        .boolean_expected => return error.BooleanExpected,
+        .array_expected => return error.ArrayExpected,
+        .generic_failure => return error.GenericFailure,
+        .pending_exception => return error.PendingException,
+        .cancelled => return error.Cancelled,
+        .escape_called_twice => return error.EscapeCalledTwice,
+        .handle_scope_mismatch => return error.HandleScopeMismatch,
+        .callback_scope_mismatch => return error.CallbackScopeMismatch,
+        .queue_full => return error.QueueFull,
+        .closing => return error.Closing,
+        .bigint_expected => return error.BigIntExpected,
+        .date_expected => return error.DateExpected,
+        .arraybuffer_expected => return error.ArrayBufferExpected,
+        .detachable_arraybuffer_expected => return error.DetachableArrayBufferExpected,
+        .would_deadlock => return error.WouldDeadlock,
+        .no_external_buffers_allowed => return error.NoExternalBuffersAllowed,
+        .cannot_run_js => return error.CannotRunJS,
+    }
+}

--- a/zig/root.zig
+++ b/zig/root.zig
@@ -4,6 +4,7 @@ const persistent_merkle_tree = @import("persistent_merkle_tree.zig");
 const bytes = @import("bytes.zig");
 const lmdb = @import("lmdb.zig");
 const leveldb = @import("leveldb.zig");
+const napi = @import("napi.zig");
 
 comptime {
     std.testing.refAllDecls(hashtree);
@@ -11,4 +12,5 @@ comptime {
     std.testing.refAllDecls(bytes);
     std.testing.refAllDecls(lmdb);
     std.testing.refAllDecls(leveldb);
+    std.testing.refAllDecls(napi);
 }


### PR DESCRIPTION
- do not merge, this is just for demo purposes
- This shows how work can be delegated to a background worker and have a promise returned which is resolved when the work is complete
  - the `include/` folder is just the napi headers
  - this just uses https://nodejs.org/api/n-api.html#simple-asynchronous-operations
  - look at the additions to `zig/leveldb.zig`, its quite verbose, but it goes like:
    - `leveldb_db_get_promise` gets the input, creates+returns the promise and creates+queues the async work
    - `leveldb_db_get_execute_callback` is where the "heavy work / io" is performed (can't use napi in this fn)
    - `leveldb_db_get_complete_callback` is where the result is wrapped / napi-ified
- the added test shows that (at least for this microbenchmark) that the sync version is faster than even the time to return the promise in the async version
  - this shows that we need to carefully apply this pattern only where it "makes sense", eg where the work takes more than ~0.1ms